### PR TITLE
chore(cvsb-19660): remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15725,12 +15725,6 @@
         }
       }
     },
-    "serverless-dependency-invoke": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/serverless-dependency-invoke/-/serverless-dependency-invoke-0.0.9.tgz",
-      "integrity": "sha512-5CYGhK3/RIdMshYahXqboOVniO2rYxT0fW3SGuKqplAN7IOwMGXiYSksAovSw0dvZsjMy1j00B6QIGWnedQRNw==",
-      "dev": true
-    },
     "serverless-offline": {
       "version": "5.12.0",
       "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-5.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "lambda-tester": "^4.0.1",
     "prettier": "^2.3.2",
     "serverless": "^2.46.0",
-    "serverless-dependency-invoke": "^0.0.9",
     "serverless-offline": "^5.12.0",
     "serverless-plugin-tracing": "^2.0.0",
     "serverless-plugin-typescript": "^1.1.9",


### PR DESCRIPTION
## Remove unused dependency

Removing  serverless-dependency-invoke as it is not used
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-19660)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [ ] Delete branch after merge
