### PR TITLE
fix(cvsb-19689): add IsTrailer attribute for pass cert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8973,22 +8973,22 @@
       }
     },
     "hapi-plugin-websocket": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/hapi-plugin-websocket/-/hapi-plugin-websocket-2.3.4.tgz",
-      "integrity": "sha512-QsoTR6NdCzhVnQe4denz0X+2QbhP44guPhxENqU/EPNXERIrfCV6h31eedZR176nMEfu3BSegLhqfQ6jwAv2Rg==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/hapi-plugin-websocket/-/hapi-plugin-websocket-2.3.5.tgz",
+      "integrity": "sha512-VwEzuy4zNV9g9KWI3H67gjB36Ia/Of3U7BDe05gRLA+1eljOp6nw7kf6QesQOFZT5573CvxNxS7BFQvsjTvLAA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.1.2",
+        "@hapi/boom": "9.1.3",
         "@hapi/hoek": "9.2.0",
-        "urijs": "1.19.6",
-        "websocket-framed": "1.2.5",
-        "ws": "7.5.1"
+        "urijs": "1.19.7",
+        "websocket-framed": "1.2.6",
+        "ws": "8.0.0"
       },
       "dependencies": {
         "@hapi/boom": {
-          "version": "9.1.2",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
-          "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+          "version": "9.1.3",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.3.tgz",
+          "integrity": "sha512-RlrGyZ603hE/eRTZtTltocRm50HHmrmL3kGOP0SQ9MasazlW1mt/fkv4C5P/6rnpFXjwld/POFX1C8tMZE3ldg==",
           "dev": true,
           "requires": {
             "@hapi/hoek": "9.x.x"
@@ -9001,9 +9001,9 @@
           "dev": true
         },
         "ws": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-          "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.0.0.tgz",
+          "integrity": "sha512-6AcSIXpBlS0QvCVKk+3cWnWElLsA6SzC0lkQ43ciEglgXJXiCWK3/CGFEJ+Ybgp006CMibamAsqOlxE9s4AvYA==",
           "dev": true
         }
       }
@@ -12418,9 +12418,9 @@
       }
     },
     "jszip": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
-      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -16946,9 +16946,9 @@
       }
     },
     "tar": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
-      "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -17763,9 +17763,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
-      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==",
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA==",
       "dev": true
     },
     "urix": {
@@ -17993,9 +17993,9 @@
       "dev": true
     },
     "websocket-framed": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/websocket-framed/-/websocket-framed-1.2.5.tgz",
-      "integrity": "sha512-iqz8MvWXGcucx5VzRMyfgM6iCR0QuubGRakJJdIJtz5zXzm4hbsqxnXXgcqqY5ZoA2P+6xghbfn9u5CFZPW3lw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/websocket-framed/-/websocket-framed-1.2.6.tgz",
+      "integrity": "sha512-jfkpKBgpfffPtVIovN7+Sv0KJFl967l6PrSbaM1BYW3wx/4hKajoMIoALZ8mzPsCa1wIfYO8anEspx0CsEMkPw==",
       "dev": true,
       "requires": {
         "encodr": "1.3.0",

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -210,7 +210,6 @@ class CertificateGenerationService {
           : await this.getOdometerHistory(vin);
       const TrnObj = this.isValidForTrn(
         vehicleType,
-        testResult.vin,
         makeAndModel
       )
         ? await this.getTrailerRegistrationObject(
@@ -227,7 +226,7 @@ class CertificateGenerationService {
           ...passData,
           ...makeAndModel,
           ...odometerHistory,
-          Trn: TrnObj?.Trn
+          ...TrnObj,
         };
       }
       if (testTypes.testResult !== TEST_RESULTS.PASS) {
@@ -699,7 +698,6 @@ class CertificateGenerationService {
    */
   public isValidForTrn(
     vehicleType: string,
-    vin: string,
     makeAndModel: IMakeAndModel
   ): boolean {
     return makeAndModel && vehicleType === VEHICLE_TYPES.TRL;

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -1740,6 +1740,7 @@ describe("cert-gen", () => {
                 Make: "Mercedes",
                 Model: "632,01",
                 Trn: "ABC123",
+                IsTrailer: true
               },
               Signature: {
                 ImageType: "png",
@@ -1833,6 +1834,7 @@ describe("cert-gen", () => {
                 Make: "Mercedes",
                 Model: "632,01",
                 Trn: "ABC123",
+                IsTrailer: true,
               },
               Signature: {
                 ImageType: "png",
@@ -1905,6 +1907,7 @@ describe("cert-gen", () => {
                 SeatBeltNumber: 2,
                 Make: "Mercedes",
                 Model: "632,01",
+                IsTrailer: true,
               },
               Signature: {
                 ImageType: "png",
@@ -2039,6 +2042,7 @@ describe("cert-gen", () => {
                 Make: "Mercedes",
                 Model: "632,01",
                 Trn: "ABC123",
+                IsTrailer: true,
               },
               FAIL_DATA: {
                 TestNumber: "W01A00310",
@@ -2176,6 +2180,7 @@ describe("cert-gen", () => {
                 Make: "Mercedes",
                 Model: "632,01",
                 Trn: "ABC123",
+                IsTrailer: true,
               },
               FAIL_DATA: {
                 TestNumber: "W01A00310",


### PR DESCRIPTION
## Update doc gen payload for TRN handling

add isTrailer attribute to `DATA` for doc-gen to handle `trn` field on the certificate. 
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-19689)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [ ] Delete branch after merge
