### PR TITLE
feat(VTA-297): Reverse tester name on certificates

### DIFF
--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -162,6 +162,15 @@ class CertificateGenerationService {
    * @param testResult - source test result for certificate generation
    */
   public async generatePayload(testResult: any) {
+    let name = testResult.testerName;
+
+    const nameArrayList: string[] = name.split(",");
+
+    if (nameArrayList.length === 2) {
+      name = name.split(", ").reverse().join(" ");
+      testResult.testerName = name;
+    }
+
     const signature: string | null = await this.getSignature(
       testResult.testerStaffId
     );

--- a/tests/resources/queue-event-pass.json
+++ b/tests/resources/queue-event-pass.json
@@ -29,6 +29,26 @@
       "eventSource": "aws:sqs",
       "eventSourceARN": "arn:aws:sqs:eu-west-2:006106226016:cert-gen-q",
       "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "e48c54a0-7027-4e37-b7e8-c8d231511c60",
+      "receiptHandle": "AQEBJcBvTRZ1W2LSaUJ0g0ELXlqA8WCL4zJxO63wu0YOVhx44xxxPhsnc+/Q9+1vOPYO+3HupEjXzGRSvfPY5rEEJkgCJe4/RQ+q2kU5LsmJEr1qE/CTdIYe5X/75XeMQ523KKpdNsD9tRhyvEpPpSu50byGbz7J0JyR6lu1E6Q4YuB4QNm+ev1obPMLdEt8RhgvIi/NfEfQf0L1r3TPi3wLho1R61PllPm27He8/1CjCnMyWBzgX+DCjJ7vyRXObMZ/MbhMBKbYpeTcejsKpYX//PPr1yvldp1YPC0wPKp+iqmWxoDDeHXbo8xYRFXDA8rnY5RfkwxxffH7o534vYn8FCZEtqybQuo7pumu6Ah9PsC05tP38syU71ltasljGIA35BgCdSO+9r5rTaBnbO9++Q==",
+      "body": "{\"testerStaffId\":\"1\",\"testStartTimestamp\":\"2019-02-26T14:50:44.279Z\",\"odometerReadingUnits\":\"kilometres\",\"testEndTimestamp\":\"2019-02-26T15:02:10.761Z\",\"testStatus\":\"submitted\",\"testTypes\":{\"testNumber\":\"W01A00310\",\"prohibitionIssued\":false,\"testCode\":\"aas\",\"lastUpdatedAt\":\"2019-02-26T15:29:39.537Z\",\"testAnniversaryDate\":\"2019-12-26T15:29:40.032Z\",\"numberOfSeatbeltsFitted\":2,\"testTypeEndTimestamp\":\"2019-02-26T15:02:37.392Z\",\"lastSeatbeltInstallationCheckDate\":\"2019-02-26\",\"createdAt\":\"2019-02-26T15:29:39.537Z\",\"testExpiryDate\":\"2020-02-25T15:29:40.032Z\",\"testTypeId\":\"1\",\"testTypeStartTimestamp\":\"2019-02-26T14:51:09.149Z\",\"certificateNumber\":\"123\",\"seatbeltInstallationCheckDate\":true,\"testTypeName\":\"Annual test\",\"defects\":[],\"name\":\"Annual test\",\"testResult\":\"pass\"},\"vehicleClass\":{\"code\":\"s\",\"description\":\"small psv (ie: less than or equal to 22 seats)\"},\"testResultId\":\"1\",\"vehicleSize\":\"small\",\"vin\":\"XMGDE02FS0H012345\",\"testStationName\":\"Abshire-Kub\",\"vehicleId\":\"BQ91YHQ\",\"countryOfRegistration\":\"gb\",\"vehicleType\":\"psv\",\"preparerId\":\"AK4434\",\"preparerName\":\"Durrell Vehicles Limited\",\"odometerReading\":12312,\"vehicleConfiguration\":\"rigid\",\"testStationType\":\"gvts\",\"testerName\":\"CVS, Dev1\",\"vrm\":\"BQ91YHQ\",\"testStationPNumber\":\"09-4129632\",\"numberOfSeats\":50,\"testerEmailAddress\":\"cvs.dev1@dvsagov.onmicrosoft.com\",\"euVehicleCategory\":\"m1\",\"order\":{\"current\":1,\"total\":2}}",
+      "messageAttributes": {},
+      "md5OfBody": "9586727cbc9f3312542387099b60982c",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:006106226016:cert-gen-q",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "e48c54a0-7027-4e37-b7e8-c8d231511c60",
+      "receiptHandle": "AQEBJcBvTRZ1W2LSaUJ0g0ELXlqA8WCL4zJxO63wu0YOVhx44xxxPhsnc+/Q9+1vOPYO+3HupEjXzGRSvfPY5rEEJkgCJe4/RQ+q2kU5LsmJEr1qE/CTdIYe5X/75XeMQ523KKpdNsD9tRhyvEpPpSu50byGbz7J0JyR6lu1E6Q4YuB4QNm+ev1obPMLdEt8RhgvIi/NfEfQf0L1r3TPi3wLho1R61PllPm27He8/1CjCnMyWBzgX+DCjJ7vyRXObMZ/MbhMBKbYpeTcejsKpYX//PPr1yvldp1YPC0wPKp+iqmWxoDDeHXbo8xYRFXDA8rnY5RfkwxxffH7o534vYn8FCZEtqybQuo7pumu6Ah9PsC05tP38syU71ltasljGIA35BgCdSO+9r5rTaBnbO9++Q==",
+      "body": "{\"testerStaffId\":\"1\",\"testStartTimestamp\":\"2019-02-26T14:50:44.279Z\",\"odometerReadingUnits\":\"kilometres\",\"testEndTimestamp\":\"2019-02-26T15:02:10.761Z\",\"testStatus\":\"submitted\",\"testTypes\":{\"testNumber\":\"W01A00310\",\"prohibitionIssued\":false,\"testCode\":\"aas\",\"lastUpdatedAt\":\"2019-02-26T15:29:39.537Z\",\"testAnniversaryDate\":\"2019-12-26T15:29:40.032Z\",\"numberOfSeatbeltsFitted\":2,\"testTypeEndTimestamp\":\"2019-02-26T15:02:37.392Z\",\"lastSeatbeltInstallationCheckDate\":\"2019-02-26\",\"createdAt\":\"2019-02-26T15:29:39.537Z\",\"testExpiryDate\":\"2020-02-25T15:29:40.032Z\",\"testTypeId\":\"1\",\"testTypeStartTimestamp\":\"2019-02-26T14:51:09.149Z\",\"certificateNumber\":\"123\",\"seatbeltInstallationCheckDate\":true,\"testTypeName\":\"Paid roadworthiness retest\",\"defects\":[],\"name\":\"Paid retest\",\"testResult\":\"pass\"},\"vehicleClass\":{\"code\":\"s\",\"description\":\"small psv (ie: less than or equal to 22 seats)\"},\"testResultId\":\"1\",\"vehicleSize\":\"small\",\"vin\":\"XMGDE02FS0H012345\",\"testStationName\":\"Abshire-Kub\",\"vehicleId\":\"BQ91YHQ\",\"countryOfRegistration\":\"gb\",\"vehicleType\":\"psv\",\"preparerId\":\"AK4434\",\"preparerName\":\"Durrell Vehicles Limited\",\"odometerReading\":12312,\"vehicleConfiguration\":\"rigid\",\"testStationType\":\"gvts\",\"testerName\":\"CVS, Test, Dev1\",\"vrm\":\"BQ91YHQ\",\"testStationPNumber\":\"09-4129632\",\"numberOfSeats\":50,\"testerEmailAddress\":\"cvs.dev1@dvsagov.onmicrosoft.com\",\"euVehicleCategory\":\"m1\",\"order\":{\"current\":1,\"total\":2}}",
+      "messageAttributes": {},
+      "md5OfBody": "9586727cbc9f3312542387099b60982c",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:006106226016:cert-gen-q",
+      "awsRegion": "eu-west-2"
     }
   ]
 }

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -44,6 +44,127 @@ describe("cert-gen", () => {
 
     context("when a passing test result is read from the queue", () => {
       const event: any = { ...queueEventPass };
+      const testResult: any = JSON.parse(event.Records[3].body);
+      const testResult2: any = JSON.parse(event.Records[4].body);
+
+      context("and a payload is generated", () => {
+        context("and no signatures were found in the bucket", () => {
+          it("should return a VTP20 payload without signature and the issuers name should have been swapped", () => {
+            const expectedResult: any = {
+              Watermark: "NOT VALID",
+              DATA: {
+                TestNumber: "W01A00310",
+                TestStationPNumber: "09-4129632",
+                TestStationName: "Abshire-Kub",
+                CurrentOdometer: {
+                  value: 12312,
+                  unit: "kilometres",
+                },
+                IssuersName: "Dev1 CVS",
+                DateOfTheTest: "26.02.2019",
+                CountryOfRegistrationCode: "gb",
+                VehicleEuClassification: "M1",
+                RawVIN: "XMGDE02FS0H012345",
+                RawVRM: "BQ91YHQ",
+                ExpiryDate: "25.02.2020",
+                EarliestDateOfTheNextTest: "26.12.2019",
+                SeatBeltTested: "Yes",
+                SeatBeltPreviousCheckDate: "26.02.2019",
+                SeatBeltNumber: 2,
+                Make: "Mercedes",
+                Model: "632,01",
+                OdometerHistoryList: [
+                  {
+                    value: 350000,
+                    unit: "kilometres",
+                    date: "14.01.2019",
+                  },
+                  {
+                    value: 350000,
+                    unit: "kilometres",
+                    date: "14.01.2019",
+                  },
+                  {
+                    value: 350000,
+                    unit: "kilometres",
+                    date: "14.01.2019",
+                  },
+                ],
+              },
+              Signature: {
+                ImageType: "png",
+                ImageData: null,
+              },
+            };
+
+            return certificateGenerationService
+                .generatePayload(testResult)
+                .then((payload: any) => {
+                  expect(payload).toEqual(expectedResult);
+                });
+          });
+        });
+        context("and no signatures were found in the bucket", () => {
+          it("should return a VTP20 payload without signature and the issuers name should have not been swapped", () => {
+            const expectedResult: any = {
+              Watermark: "NOT VALID",
+              DATA: {
+                TestNumber: "W01A00310",
+                TestStationPNumber: "09-4129632",
+                TestStationName: "Abshire-Kub",
+                CurrentOdometer: {
+                  value: 12312,
+                  unit: "kilometres",
+                },
+                IssuersName: "CVS, Test, Dev1",
+                DateOfTheTest: "26.02.2019",
+                CountryOfRegistrationCode: "gb",
+                VehicleEuClassification: "M1",
+                RawVIN: "XMGDE02FS0H012345",
+                RawVRM: "BQ91YHQ",
+                ExpiryDate: "25.02.2020",
+                EarliestDateOfTheNextTest: "26.12.2019",
+                SeatBeltTested: "Yes",
+                SeatBeltPreviousCheckDate: "26.02.2019",
+                SeatBeltNumber: 2,
+                Make: "Mercedes",
+                Model: "632,01",
+                OdometerHistoryList: [
+                  {
+                    value: 350000,
+                    unit: "kilometres",
+                    date: "14.01.2019",
+                  },
+                  {
+                    value: 350000,
+                    unit: "kilometres",
+                    date: "14.01.2019",
+                  },
+                  {
+                    value: 350000,
+                    unit: "kilometres",
+                    date: "14.01.2019",
+                  },
+                ],
+              },
+              Signature: {
+                ImageType: "png",
+                ImageData: null,
+              },
+            };
+
+            return certificateGenerationService
+                .generatePayload(testResult2)
+                .then((payload: any) => {
+                  expect(payload).toEqual(expectedResult);
+                });
+          });
+        });
+      });
+    });
+
+    context("when a passing test result is read from the queue", () => {
+      const event: any = { ...queueEventPass };
       const testResult: any = JSON.parse(event.Records[0].body);
 
       context("and a payload is generated", () => {


### PR DESCRIPTION
## KT - (BE) Reverse tester name on certificates

When a comma is present within the tester name attribute in Azure AD, the name will be flipped to present 'Forename Surname' on the certificate
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-15219)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [ ] Delete branch after merge
