### PR TITLE
fix(VTA-458): excluded abandoned and cancelled tests from odometer hi…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,19 +5330,26 @@
       }
     },
     "aws-sdk": {
-      "version": "2.562.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.562.0.tgz",
-      "integrity": "sha512-Uvt7qUXufjSxWMMfTs62xulGY7wnRut3y3daDtHSUdY62BnGjZGpp0dq/RW/bNi3aAjogEZNjWNZkLdtkHFeiQ==",
+      "version": "2.1067.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1067.0.tgz",
+      "integrity": "sha512-3Ys1k4cNQy4z37IpPjQ9c5ldkXMeZGbWoarKHynPPY3WCEj+Nw2u6zk484fA9/lTHNN3YesLuZ0OmEzGgjFEOw==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "jmespath": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+          "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+        }
       }
     },
     "aws-sign2": {
@@ -5931,9 +5938,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -12152,7 +12159,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "security-checks": "git secrets --scan && git log -p | scanrepo",
     "prepush": "npm run test && npm run build && npm run test-i",
     "sonar-scanner": "sonar-scanner",
-    "audit": "npm audit",
+    "audit": "npm audit --prod",
     "package": "mkdir -p ${ZIP_NAME} && cp package.json package-lock.json ${ZIP_NAME}/ && cp -r .build/src/* ${ZIP_NAME}/ && cd ${ZIP_NAME} && npm ci --production && rm package.json package-lock.json && zip -qr ../${ZIP_NAME}.zip .",
     "tools-setup": "echo 'nothing to do'"
   },
@@ -50,7 +50,7 @@
   "license": "ISC",
   "dependencies": {
     "aws-lambda": "^1.0.5",
-    "aws-sdk": "^2.562.0",
+    "aws-sdk": "^2.1067.0",
     "aws-xray-sdk": "^2.4.0",
     "moment": "^2.24.0",
     "node-yaml": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run test:unit -- --coveragePathIgnorePatterns='<rootDir>/tests/' --coverage",
     "test-i": "BRANCH=local jest --testMatch=\"**/*.intTest.ts\" --runInBand",
     "lint": "tslint src/**/*.ts tests/**/*.ts -q",
-    "security-checks": "git secrets --scan && git log -p | scanrepo",
+    "security-checks": "git secrets --scan",
     "prepush": "npm run test && npm run build && npm run test-i",
     "sonar-scanner": "sonar-scanner",
     "audit": "npm audit --prod",

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -501,13 +501,17 @@ class CertificateGenerationService {
           // Remove the first result as it should be the current one.
           testResults.shift();
 
-          // Remove any failed test results as they should not to be included in Odometer History
-          let filteredTestResults: any[] = testResults.filter((testResult) => {
+          // Set the array to only submitted tests (exclude cancelled)
+          const submittedTests = testResults.filter((testResult) => {
+              return testResult.testStatus === "submitted";
+            });
+          let filteredTestResults: any[] = submittedTests.filter((testResult) => {
             const { testTypes } = testResult;
             if (!testTypes) {
               return testResult;
             }
-            if (testTypes.filter((testType: ITestType) => testType.testResult !== "fail").length) {
+            // Only include passed and prs results (exclude failed and abandoned)
+            if (testTypes.filter((testType: ITestType) => testType.testResult === "pass" || testType.testResult === "prs").length) {
               return testResult;
             }
           });


### PR DESCRIPTION
…story

## Exclude abandoned and cancelled tests on odometer history on certs following 2.37 release

_only display odometer history where test type is pass/PRS and test status = submitted_
[VTA-458](https://jira.dvsacloud.uk/browse/VTA-458)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [ ] Delete branch after merge
