### PR TITLE
CB2-6766 amend case of reissue reason

### DIFF
--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -201,7 +201,7 @@ class CertificateGenerationService {
         for (const testType of history.testTypes) {
           if (testType.testCode === testTypes.testCode) {
             payload.Reissue = {
-              Reason: "REPLACEMENT",
+              Reason: "Replacement",
               Issuer: testResult.createdByName,
               Date: moment(testResult.createdAt).format("DD.MM.YYYY")
             };

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -425,7 +425,7 @@ describe("cert-gen", () => {
                 ImageData: null,
               },
               Reissue: {
-                Reason: "REPLACEMENT",
+                Reason: "Replacement",
                 Issuer: "Joe Smith",
                 Date: "14.12.2022"
               }


### PR DESCRIPTION
## Description

Move the replacement specific text on the certificate. It was found that the original details on [CB2-6766](https://dvsa.atlassian.net/browse/CB2-6766) were not correct and a new template provided.

## Evidence of Completion
Before:
![image](https://user-images.githubusercontent.com/13391709/209154028-2dae19f2-0c0a-41d2-8e13-08ce0530d64a.png)
After:
![image](https://user-images.githubusercontent.com/13391709/209153221-34b00425-869a-4c4f-a602-c9c98ae37b97.png)
