### PR TITLE
VTA-1746: Implement Switch to turn off Welsh Cert Gen

### DIFF
--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -70,11 +70,19 @@ class CertificateGenerationService {
     const config: IMOTConfig = this.config.getMOTConfig();
     const iConfig: IInvokeConfig = this.config.getInvokeConfig();
     const testType: any = testResult.testTypes;
+    const { STOP_WELSH_GEN } = process.env;
 
-    // Find out if Welsh certificate is needed
-    const testStations = await this.getTestStations();
-    const testStationPostcode = this.getThisTestStation(testStations, testResult.testStationPNumber);
-    const isTestStationWelsh = testStationPostcode ? await this.lookupPostcode(testStationPostcode) : false;
+    let isTestStationWelsh = false;
+
+    // Circumvent bilingual certificate generation and logic if EV set to TRUE
+    if (STOP_WELSH_GEN === undefined || STOP_WELSH_GEN.toUpperCase() === "FALSE") {
+      // Find out if Welsh certificate is needed
+      const testStations = await this.getTestStations();
+      const testStationPostcode = this.getThisTestStation(testStations, testResult.testStationPNumber);
+      isTestStationWelsh = testStationPostcode ? await this.lookupPostcode(testStationPostcode) : false;
+    } else {
+      console.log(`Welsh certificate generation deactivated via environment variable set to ${STOP_WELSH_GEN}`);
+    }
 
     const payload: string = JSON.stringify(await this.generatePayload(testResult, isTestStationWelsh));
 

--- a/tests/unit/CertificateGenerationService.unitTest.ts
+++ b/tests/unit/CertificateGenerationService.unitTest.ts
@@ -593,6 +593,25 @@ describe("Certificate Generation Service", () => {
     });
   });
 
+  describe("welsh address logic", () => {
+    context("test STOP_WELSH_GEN environment variable", () => {
+      it("should circumvent the Welsh certificate generation logic and log message if set to true", async () => {
+        process.env.STOP_WELSH_GEN = "TRUE";
+        const logSpy = jest.spyOn(console, "log");
+        const certGenSvc = new CertificateGenerationService(
+            null as any,
+            new LambdaService(new Lambda())
+        );
+        await certGenSvc.generateCertificate(mockTestResult)
+            .catch(() => {
+              expect(logSpy).toHaveBeenCalledWith(
+                  "Welsh certificate generation deactivated via environment variable set to TRUE"
+              );
+            });
+      });
+    });
+  });
+
   describe("welsh address function", () => {
     context("test getTestStations method", () => {
       it("should return a postcode if pNumber exists in the list of test stations", () => {


### PR DESCRIPTION
## Implement Kill Switch into **cvs-tsk-cert-gen**

Implemented a new EV called STOP_WELSH_GEN, which is used to circumvent the welsh logic (test-stations call and address service call). If the EV does not exist, or if it does exist and is set to any value other than 'false' then the welsh logic will be circumvented and logged accordingly.

[https://dvsa.atlassian.net/browse/VTA-1746](VTA-1746)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [X] PR title includes the JIRA ticket number
- [X] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo
- [ ] Delete branch after merge
