### PR TITLE
CB2-9550: Build Retry Process for Ref Data

### DIFF
--- a/src/models/Enums.ts
+++ b/src/models/Enums.ts
@@ -6,6 +6,7 @@ export enum ERRORS {
     RETRO_ERROR_OR_CVS_UPDATED = "Not eligible for certificate generation.",
     SECRET_ENV_VAR_NOT_EXIST = "SECRET_KEY environment variable does not exist.",
     SECRET_DETAILS_NOT_FOUND = "No secret details found.",
+    ADDRESS_BOOLEAN_DOES_NOT_EXIST = "Payload does not include boolean value for isWelshAddress: "
 }
 
 export enum VEHICLE_TYPES {

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -150,10 +150,11 @@ class CertificateGenerationService {
             });
     }
 
-  /**
-   * Method to retrieve Test Station details from API
-   */
-  public async getTestStations() {
+    /**
+     * Method to retrieve Test Station details from API
+     * @returns list of test stations
+     */
+  public async getTestStations(): Promise<ITestStation[]> {
       const config: IInvokeConfig = this.config.getInvokeConfig();
       const invokeParams: any = {
           FunctionName: config.functions.testStations.name,
@@ -181,7 +182,7 @@ class CertificateGenerationService {
               return testStations;
           } catch (error) {
               retries++;
-              console.error(`There was an error retrieving the test stations: ${error}`);
+              console.error(`There was an error retrieving the test stations on attempt ${retries}: ${error}`);
           }
       }
       return testStations;
@@ -236,7 +237,7 @@ class CertificateGenerationService {
                 return addressResponse.data.isWelshAddress;
             } catch (error) {
                 retries++;
-                console.log(`Error looking up postcode ${postcode}`);
+                console.log(`Error looking up postcode ${postcode} on attempt ${retries}`);
                 console.log(error);
             }
         }
@@ -871,8 +872,9 @@ class CertificateGenerationService {
 
   /**
    * Method used to retrieve the Welsh translations for the certificates
+   * @returns a list of defects
    */
-  public async getDefectTranslations() {
+  public async getDefectTranslations(): Promise<IDefectParent[]> {
     const config: IInvokeConfig = this.config.getInvokeConfig();
     const invokeParams: any = {
       FunctionName: config.functions.defects.name,
@@ -898,7 +900,7 @@ class CertificateGenerationService {
             return defects;
         } catch (error) {
             retries++;
-            console.error(`There was an error retrieving the welsh defect translations: ${error}`);
+            console.error(`There was an error retrieving the welsh defect translations on attempt ${retries}: ${error}`);
         }
     }
     return defects;

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -240,6 +240,7 @@ class CertificateGenerationService {
                     throw new HTTPError(400, `${ERRORS.ADDRESS_BOOLEAN_DOES_NOT_EXIST} ${JSON.stringify(addressResponse)}.`);
                 }
                 isWelsh = addressResponse.data.isWelshAddress;
+                console.log(`Return value for isWelsh for ${postcode} is ${isWelsh}`);
                 return isWelsh;
             } catch (error) {
                 retries++;

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -154,42 +154,37 @@ class CertificateGenerationService {
    * Method to retrieve Test Station details from API
    */
   public async getTestStations() {
-    const config: IInvokeConfig = this.config.getInvokeConfig();
-    const invokeParams: any = {
-      FunctionName: config.functions.testStations.name,
-      InvocationType: "RequestResponse",
-      LogType: "Tail",
-      Payload: JSON.stringify({
-        httpMethod: "GET",
-        path: `/test-stations/`,
-      }),
-    };
-    let testStations: ITestStation[] = [];
-    return this.lambdaClient
-      .invoke(invokeParams)
-      .then(
-        (
-          response: PromiseResult<Lambda.Types.InvocationResponse, AWSError>
-        ) => {
-          const payload: any =
-            this.lambdaClient.validateInvocationResponse(response);
-          testStations = JSON.parse(payload.body);
+      const config: IInvokeConfig = this.config.getInvokeConfig();
+      const invokeParams: any = {
+          FunctionName: config.functions.testStations.name,
+          InvocationType: "RequestResponse",
+          LogType: "Tail",
+          Payload: JSON.stringify({
+              httpMethod: "GET",
+              path: `/test-stations/`,
+          }),
+      };
+      let testStations: ITestStation[] = [];
+      let retries = 0;
 
-          if (!testStations || testStations.length === 0) {
-            throw new HTTPError(
-              400,
-              `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`
-            );
+      while (retries < 3) {
+          try {
+              const response: PromiseResult<Lambda.Types.InvocationResponse, AWSError> = await this.lambdaClient.invoke(invokeParams);
+              const payload: any = this.lambdaClient.validateInvocationResponse(response);
+              const testStationsParsed = JSON.parse(payload.body);
+
+              if (!testStationsParsed || testStationsParsed.length === 0) {
+                  throw new HTTPError(400, `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`
+                  );
+              }
+              testStations = testStationsParsed;
+              return testStations;
+          } catch (error) {
+              retries++;
+              console.error(`There was an error retrieving the test stations: ${error}`);
           }
-          return testStations;
-        }
-      )
-      .catch((error: AWSError | Error) => {
-        console.error(
-          `There was an error retrieving the test stations: ${error}`
-        );
-        return testStations;
-      });
+      }
+      return testStations;
   }
 
   /**
@@ -230,22 +225,22 @@ class CertificateGenerationService {
     const secretConfig = await this.getSecret();
 
     if (secretConfig) {
-      const addressResponse: boolean = await axios({
-        method: "get",
-        url: secretConfig.url + "/" + postcode,
-        headers: {"x-api-key": secretConfig.key},
-      })
-          .then((response) => {
-            return response.data.isWelshAddress;
-          })
-          .catch((error) => {
-            console.log(`Error looking up postcode ${postcode}`);
-            console.log(error);
-            return false;
-          });
-
-      console.log(`Return value for isWelsh for ${postcode} is ${addressResponse}`);
-      return addressResponse;
+        let retries = 0;
+        while (retries < 3) {
+            try {
+                const addressResponse = await axios({
+                    method: "get",
+                    url: secretConfig.url + "/" + postcode,
+                    headers: {"x-api-key": secretConfig.key},
+                });
+                return addressResponse.data.isWelshAddress;
+            } catch (error) {
+                retries++;
+                console.log(`Error looking up postcode ${postcode}`);
+                console.log(error);
+            }
+        }
+        return false;
     } else {
       console.log(`SMC Postcode lookup details not found. Return value for isWelsh for ${postcode} is false`);
       return false;
@@ -889,36 +884,24 @@ class CertificateGenerationService {
       }),
     };
     let defects: IDefectParent[] = [];
-    return this.lambdaClient
-      .invoke(invokeParams)
-      .then(
-        (
-          response: PromiseResult<Lambda.Types.InvocationResponse, AWSError>
-        ) => {
-          const payload: any =
-            this.lambdaClient.validateInvocationResponse(response);
-          defects = JSON.parse(payload.body);
+    let retries = 0;
+    while (retries < 3) {
+        try {
+            const response: PromiseResult<Lambda.Types.InvocationResponse, AWSError> = await this.lambdaClient.invoke(invokeParams);
+            const payload: any = this.lambdaClient.validateInvocationResponse(response);
+            const defectsParsed = JSON.parse(payload.body);
 
-          if (!defects || defects.length === 0) {
-            throw new HTTPError(
-              400,
-              `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`
-            );
-          }
-
-          console.log(
-            `Successfully retrieved ${defects.length} welsh defects translations.`
-          );
-
-          return defects;
+            if (!defectsParsed || defectsParsed.length === 0) {
+                throw new HTTPError(400, `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`);
+            }
+            defects = defectsParsed;
+            return defects;
+        } catch (error) {
+            retries++;
+            console.error(`There was an error retrieving the welsh defect translations: ${error}`);
         }
-      )
-      .catch((error: AWSError | Error) => {
-        console.error(
-          `There was an error retrieving the welsh defect translations: ${error}`
-        );
-        return defects;
-      });
+    }
+    return defects;
   }
 
   /**

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -222,10 +222,11 @@ class CertificateGenerationService {
    * @param postcode
    * @returns boolean true if Welsh
    */
-  public async lookupPostcode(postcode: string) {
+  public async lookupPostcode(postcode: string): Promise<boolean> {
     const secretConfig = await this.getSecret();
 
     if (secretConfig) {
+        let isWelsh: boolean = false;
         let retries = 0;
         while (retries < 3) {
             try {
@@ -234,7 +235,12 @@ class CertificateGenerationService {
                     url: secretConfig.url + "/" + postcode,
                     headers: {"x-api-key": secretConfig.key},
                 });
-                return addressResponse.data.isWelshAddress;
+
+                if (typeof addressResponse.data.isWelshAddress !== "boolean") {
+                    throw new HTTPError(400, `${ERRORS.ADDRESS_BOOLEAN_DOES_NOT_EXIST} ${JSON.stringify(addressResponse)}.`);
+                }
+                isWelsh = addressResponse.data.isWelshAddress;
+                return isWelsh;
             } catch (error) {
                 retries++;
                 console.log(`Error looking up postcode ${postcode} on attempt ${retries}`);

--- a/tests/unit/CertificateGenerationService.unitTest.ts
+++ b/tests/unit/CertificateGenerationService.unitTest.ts
@@ -831,7 +831,7 @@ describe("Certificate Generation Service", () => {
 
         const testStations = await certGenSvc.getTestStations();
 
-        expect(logSpy).toHaveBeenLastCalledWith("There was an error retrieving the test stations: Error");
+        expect(logSpy).toHaveBeenLastCalledWith("There was an error retrieving the test stations on attempt 3: Error");
         expect(logSpy).toHaveBeenCalledTimes(3);
         expect(testStations).not.toBeNull();
         logSpy.mockClear();
@@ -913,7 +913,7 @@ describe("Certificate Generation Service", () => {
 
         const defects = await certGenSvc.getDefectTranslations();
 
-        expect(logSpy).toHaveBeenLastCalledWith("There was an error retrieving the welsh defect translations: Error");
+        expect(logSpy).toHaveBeenLastCalledWith("There was an error retrieving the welsh defect translations on attempt 3: Error");
         expect(logSpy).toHaveBeenCalledTimes(3);
         expect(defects).not.toBeNull();
         logSpy.mockClear();


### PR DESCRIPTION
## Build Retry Process for Reference Data

As these are reference data, the lambdas may be cold by the time cert-gen needs to use then.  Build a process to retry the GET endpoints a max of 3 times, or until a successful response is received.
[CB2-9550](https://dvsa.atlassian.net/browse/CB2-9550)

This ticket also included the retry logic for CB2-9551.

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [X] PR title includes the JIRA ticket number
- [X] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo
- [ ] Delete branch after merge
