### PR TITLE
CB2:9976: Update Doc Gen to generate IVA30

### DIFF
--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -546,24 +546,26 @@ class CertificateGenerationService {
                 return docGenPayloadAdr;
             case CERTIFICATE_DATA.IVA_DATA:
                 const ivaFailDetailsForDocGen = {
-                    SerialNumber: testResult.vehicleType === "trl" ? testResult.trailerId : testResult.vrm,
-                    VehicleTrailerNrNo: testResult.vehicleType === "trl" ? testResult.trailerId : testResult.vrm,
-                    TestCategoryClass: testResult.euVehicleCategory,
-                    TestCategoryBasicNormal: this.isBasicIvaTest(testResult.testTypes.testTypeId) ? IVA_30.BASIC : IVA_30.NORMAL,
-                    Make: testResult.make,
-                    Model: testResult.model,
-                    BodyType: testResult.bodyType?.description,
-                    Date: moment(testResult.testTypes.testTypeStartTimestamp).format("DD.MM.YYYY"),
-                    ReapplicationDate: moment(testResult.testTypes.testTypeStartTimestamp)
+                    vin: testResult.vin,
+                    serialNumber: testResult.vehicleType === "trl" ? testResult.trailerId : testResult.vrm,
+                    vehicleTrailerNrNo: testResult.vehicleType === "trl" ? testResult.trailerId : testResult.vrm,
+                    testCategoryClass: testResult.euVehicleCategory,
+                    testCategoryBasicNormal: this.isBasicIvaTest(testResult.testTypes.testTypeId) ? IVA_30.BASIC : IVA_30.NORMAL,
+                    make: testResult.make,
+                    model: testResult.model,
+                    bodyType: testResult.bodyType?.description,
+                    date: moment(testResult.testTypes.testTypeStartTimestamp).format("DD/MM/YYYY"),
+                    testerName: testResult.testerName,
+                    reapplicationDate: moment(testResult.testTypes.testTypeStartTimestamp)
                         .add(6, "months")
                         .subtract(1, "day")
-                        .format("DD.MM.YYYY"),
-                    Station: testResult.testStationName,
-                    AdditionalDefects:
+                        .format("DD/MM/YYYY"),
+                    station: testResult.testStationName,
+                    additionalDefects:
                         testResult.testTypes.customDefects && testResult.testTypes.customDefects.length > 0
                             ? testResult.testTypes.customDefects
-                            : IVA_30.EMPTY_CUSTOM_DEFECTS,
-                    RequiredStandards: testResult.testTypes.requiredStandards,
+                            : [{ defectName: IVA_30.EMPTY_CUSTOM_DEFECTS, defectNotes: ""}],
+                    requiredStandards: testResult.testTypes.requiredStandards
                 };
                 console.log("CHECK HERE DOCGENPAYLOAD -> ", ivaFailDetailsForDocGen);
                 return ivaFailDetailsForDocGen;

--- a/tests/resources/doc-gen-payload-iva30.json
+++ b/tests/resources/doc-gen-payload-iva30.json
@@ -1,18 +1,25 @@
 [
   {
     "IVA_DATA": {
-      "SerialNumber": "C456789",
-      "VehicleTrailerNrNo": "C456789",
-      "TestCategoryClass": "m1",
-      "TestCategoryBasicNormal": "Basic",
-      "Make": "some make",
-      "Model": "some model",
-      "BodyType": "some bodyType",
-      "Date": "28.11.2023",
-      "ReapplicationDate": "27.05.2024",
-      "Station": "Abshire-Kub",
-      "AdditionalDefects": "N/A",
-      "RequiredStandards":[
+      "serialNumber": "C456789",
+      "vehicleTrailerNrNo": "C456789",
+      "testCategoryClass": "m1",
+      "testerName": "CVS Dev1",
+      "testCategoryBasicNormal": "Basic",
+      "make": "some make",
+      "model": "some model",
+      "bodyType": "some bodyType",
+      "date": "28/11/2023",
+      "reapplicationDate": "27/05/2024",
+      "station": "Abshire-Kub",
+      "vin": "T12876765",
+      "additionalDefects": [
+        {
+          "defectName": "N/A",
+          "defectNotes": ""
+        }
+      ],
+      "requiredStandards":[
         {
           "prs": false,
           "requiredStandard": "The exhaust must be securely mounted",
@@ -34,18 +41,25 @@
   },
   {
     "IVA_DATA": {
-      "SerialNumber": "C456789",
-      "VehicleTrailerNrNo": "C456789",
-      "TestCategoryClass": "m1",
-      "TestCategoryBasicNormal": "Basic",
-      "Make": "some make",
-      "Model": "some model",
-      "BodyType": "some bodyType",
-      "Date": "28.11.2023",
-      "ReapplicationDate": "27.05.2024",
-      "Station": "Abshire-Kub",
-      "AdditionalDefects": "N/A",
-      "RequiredStandards":[
+      "serialNumber": "C456789",
+      "vehicleTrailerNrNo": "C456789",
+      "testCategoryClass": "m1",
+      "testerName": "CVS Dev1",
+      "testCategoryBasicNormal": "Basic",
+      "make": "some make",
+      "model": "some model",
+      "bodyType": "some bodyType",
+      "date": "28/11/2023",
+      "reapplicationDate": "27/05/2024",
+      "station": "Abshire-Kub",
+      "vin": "T12876765",
+      "additionalDefects": [
+        {
+          "defectName": "N/A",
+          "defectNotes": ""
+        }
+      ],
+      "requiredStandards":[
         {
           "prs": false,
           "requiredStandard": "The exhaust must be securely mounted",

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -2285,10 +2285,15 @@ describe("cert-gen", () => {
                     () => {
                         it("should return Certificate Data with requiredStandards in IVA_DATA", async () => {
                             const expectedResult: any = {
-                                AdditionalDefects: "N/A",
-                                BodyType: "some bodyType",
-                                Date: "28.11.2023",
-                                RequiredStandards: [
+                                additionalDefects: [
+                                    {
+                                        defectName: "N/A",
+                                        defectNotes: ""
+                                    }
+                                ],
+                                bodyType: "some bodyType",
+                                date: "28/11/2023",
+                                requiredStandards: [
                                     {
                                         additionalInfo: true,
                                         additionalNotes: "The exhaust was held on with blue tac",
@@ -2304,14 +2309,16 @@ describe("cert-gen", () => {
                                         sectionNumber: "01"
                                     }
                                 ],
-                                Make: "some make",
-                                Model: "some model",
-                                ReapplicationDate: "27.05.2024",
-                                SerialNumber: "C456789",
-                                Station: "Abshire-Kub",
-                                TestCategoryBasicNormal: "Basic",
-                                TestCategoryClass: "m1",
-                                VehicleTrailerNrNo: "C456789"
+                                make: "some make",
+                                model: "some model",
+                                reapplicationDate: "27/05/2024",
+                                serialNumber: "C456789",
+                                station: "Abshire-Kub",
+                                testCategoryBasicNormal: "Basic",
+                                testCategoryClass: "m1",
+                                testerName: "CVS Dev1",
+                                vehicleTrailerNrNo: "C456789",
+                                vin: "T12876765",
                             };
 
                             return await certificateGenerationService
@@ -2329,10 +2336,15 @@ describe("cert-gen", () => {
                     () => {
                         it("should return Certificate Data with requiredStandards in IVA_DATA", async () => {
                             const expectedResult: any = {
-                                AdditionalDefects: "N/A",
-                                BodyType: "some bodyType",
-                                Date: "28.11.2023",
-                                RequiredStandards: [
+                                additionalDefects: [
+                                    {
+                                        defectName: "N/A",
+                                        defectNotes: "",
+                                    }
+                                ],
+                                bodyType: "some bodyType",
+                                date: "28/11/2023",
+                                requiredStandards: [
                                     {
                                         additionalInfo: true,
                                         additionalNotes: "The exhaust was held on with blue tac",
@@ -2361,14 +2373,16 @@ describe("cert-gen", () => {
                                         sectionNumber: "01"
                                     },
                                 ],
-                                Make: "some make",
-                                Model: "some model",
-                                ReapplicationDate: "27.05.2024",
-                                SerialNumber: "C456789",
-                                Station: "Abshire-Kub",
-                                TestCategoryBasicNormal: "Basic",
-                                TestCategoryClass: "m1",
-                                VehicleTrailerNrNo: "C456789"
+                                make: "some make",
+                                model: "some model",
+                                reapplicationDate: "27/05/2024",
+                                serialNumber: "C456789",
+                                station: "Abshire-Kub",
+                                testCategoryBasicNormal: "Basic",
+                                testCategoryClass: "m1",
+                                testerName: "CVS Dev1",
+                                vehicleTrailerNrNo: "C456789",
+                                vin: "T12876765"
                             };
 
                             return await certificateGenerationService
@@ -2386,13 +2400,13 @@ describe("cert-gen", () => {
                     () => {
                         it("should return Certificate Data with requiredStandards and additionalDefects in IVA_DATA", async () => {
                             const expectedResult: any = {
-                                AdditionalDefects: [
+                                additionalDefects: [
                                     "Some custom defect one",
                                     "Some other custom defect two"
                                 ],
-                                BodyType: "some bodyType",
-                                Date: "28.11.2023",
-                                RequiredStandards: [
+                                bodyType: "some bodyType",
+                                date: "28/11/2023",
+                                requiredStandards: [
                                     {
                                         additionalInfo: true,
                                         additionalNotes: "The exhaust was held on with blue tac",
@@ -2408,14 +2422,16 @@ describe("cert-gen", () => {
                                         sectionNumber: "01"
                                     }
                                 ],
-                                Make: "some make",
-                                Model: "some model",
-                                ReapplicationDate: "27.05.2024",
-                                SerialNumber: "C456789",
-                                Station: "Abshire-Kub",
-                                TestCategoryBasicNormal: "Basic",
-                                TestCategoryClass: "m1",
-                                VehicleTrailerNrNo: "C456789"
+                                make: "some make",
+                                model: "some model",
+                                reapplicationDate: "27/05/2024",
+                                serialNumber: "C456789",
+                                station: "Abshire-Kub",
+                                testCategoryBasicNormal: "Basic",
+                                testCategoryClass: "m1",
+                                testerName: "CVS Dev1",
+                                vehicleTrailerNrNo: "C456789",
+                                vin: "T12876765"
                             };
 
                             return await certificateGenerationService
@@ -2433,10 +2449,15 @@ describe("cert-gen", () => {
                     () => {
                         it("return Certificate Data with requiredStandards and additionalDefects in IVA_DATA", async () => {
                             const expectedResult: any = {
-                                AdditionalDefects: "N/A",
-                                BodyType: "some bodyType",
-                                Date: "28.11.2023",
-                                RequiredStandards: [
+                                additionalDefects: [
+                                    {
+                                        defectName: "N/A",
+                                        defectNotes: "",
+                                    }
+                                ],
+                                bodyType: "some bodyType",
+                                date: "28/11/2023",
+                                requiredStandards: [
                                     {
                                         additionalInfo: false,
                                         additionalNotes: null,
@@ -2451,14 +2472,16 @@ describe("cert-gen", () => {
                                         sectionNumber: "01"
                                     }
                                 ],
-                                Make: "some make",
-                                Model: "some model",
-                                ReapplicationDate: "27.05.2024",
-                                SerialNumber: "C456789",
-                                Station: "Abshire-Kub",
-                                TestCategoryBasicNormal: "Basic",
-                                TestCategoryClass: "m1",
-                                VehicleTrailerNrNo: "C456789"
+                                make: "some make",
+                                model: "some model",
+                                reapplicationDate: "27/05/2024",
+                                serialNumber: "C456789",
+                                station: "Abshire-Kub",
+                                testCategoryBasicNormal: "Basic",
+                                testCategoryClass: "m1",
+                                testerName: "CVS Dev1",
+                                vehicleTrailerNrNo: "C456789",
+                                vin: "T12876765"
                             };
 
                             return await certificateGenerationService
@@ -2476,10 +2499,15 @@ describe("cert-gen", () => {
                     () => {
                         it("should return Certificate Data with requiredStandards in IVA_DATA", async () => {
                             const expectedResult: any = {
-                                AdditionalDefects: "N/A",
-                                BodyType: "some bodyType",
-                                Date: "28.11.2023",
-                                RequiredStandards: [
+                                additionalDefects: [
+                                    {
+                                        defectName: "N/A",
+                                        defectNotes: "",
+                                    }
+                                ],
+                                bodyType: "some bodyType",
+                                date: "28/11/2023",
+                                requiredStandards: [
                                     {
                                         additionalInfo: true,
                                         additionalNotes: "The exhaust was held on with blue tac",
@@ -2495,14 +2523,16 @@ describe("cert-gen", () => {
                                         sectionNumber: "01"
                                     }
                                 ],
-                                Make: "some make",
-                                Model: "some model",
-                                ReapplicationDate: "27.05.2024",
-                                SerialNumber: "C456789",
-                                Station: "Abshire-Kub",
-                                TestCategoryBasicNormal: "Normal",
-                                TestCategoryClass: "m1",
-                                VehicleTrailerNrNo: "C456789"
+                                make: "some make",
+                                model: "some model",
+                                reapplicationDate: "27/05/2024",
+                                serialNumber: "C456789",
+                                station: "Abshire-Kub",
+                                testCategoryBasicNormal: "Normal",
+                                testCategoryClass: "m1",
+                                testerName: "CVS Dev1",
+                                vehicleTrailerNrNo: "C456789",
+                                vin: "T12876765"
                             };
 
                             return await certificateGenerationService


### PR DESCRIPTION
## Update Doc Gen to Generate IVA30

Whilst wiring up the logic in doc-gen-service it became apparent that some of the information required was missing from the payload. They were as follows:

- vin
- testerName
- format of date
- camelCased payload keys for consistency

[CB2-9976](https://dvsa.atlassian.net/browse/CB2-9976)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
