### PR TITLE
feature/cb2-12312: Refactor into repositories

### DIFF
--- a/src/defect/DefectRepository.ts
+++ b/src/defect/DefectRepository.ts
@@ -1,0 +1,57 @@
+import { InvocationRequest, InvocationResponse } from '@aws-sdk/client-lambda';
+import { toUint8Array } from '@smithy/util-utf8';
+import { Service } from 'typedi';
+import { IInvokeConfig } from '../models';
+import { ERRORS } from '../models/Enums';
+import { HTTPError } from '../models/HTTPError';
+import { IDefectParent } from '../models/IDefectParent';
+import { LambdaService } from '../services/LambdaService';
+import { Configuration } from '../utils/Configuration';
+
+@Service()
+export class DefectRepository {
+	private readonly config: Configuration = Configuration.getInstance();
+
+	constructor(private lambdaClient: LambdaService) {}
+
+	/**
+	 * Method used to retrieve the Welsh translations for the certificates
+	 * @returns a list of defects
+	 */
+	public async getDefectTranslations(): Promise<IDefectParent[]> {
+		const config: IInvokeConfig = this.config.getInvokeConfig();
+		const invokeParams: InvocationRequest = {
+			FunctionName: config.functions.defects.name,
+			InvocationType: 'RequestResponse',
+			LogType: 'Tail',
+			Payload: toUint8Array(
+				JSON.stringify({
+					httpMethod: 'GET',
+					path: '/defects/',
+				})
+			),
+		};
+		let defects: IDefectParent[] = [];
+		let retries = 0;
+		while (retries < 3) {
+			try {
+				// eslint-disable-next-line no-await-in-loop
+				const response: InvocationResponse = await this.lambdaClient.invoke(invokeParams);
+				const payload: any = this.lambdaClient.validateInvocationResponse(response);
+				const defectsParsed = JSON.parse(payload.body);
+
+				if (!defectsParsed || defectsParsed.length === 0) {
+					throw new HTTPError(400, `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`);
+				}
+				defects = defectsParsed;
+				return defects;
+			} catch (error) {
+				retries++;
+				console.error(
+					`There was an error retrieving the welsh defect translations on attempt ${retries}: ${(error as Error).message}`
+				);
+			}
+		}
+		return defects;
+	}
+}

--- a/src/services/CertificateGenerationService.ts
+++ b/src/services/CertificateGenerationService.ts
@@ -16,7 +16,6 @@ import {
 	IRequiredStandard,
 	IRoadworthinessCertificateData,
 	ITestResult,
-	ITestType,
 	IWeightDetails,
 } from '../models';
 import {
@@ -41,6 +40,7 @@ import { IFlatDefect } from '../models/IFlatDefect';
 import { IItem } from '../models/IItem';
 import { ISearchResult, TechRecordGet, TechRecordType } from '../models/Types';
 import { TechRecordRepository } from '../tech-record/TechRecordRepository';
+import { TestResultRepository } from '../test-result/TestResultRepository';
 import { TestStationRepository } from '../test-station/TestStationRepository';
 import { TrailerRepository } from '../trailer/TrailerRepository';
 import { Configuration } from '../utils/Configuration';
@@ -59,7 +59,8 @@ class CertificateGenerationService {
 		private lambdaClient: LambdaService,
 		private trailerRepository: TrailerRepository,
 		private techRecordRepository: TechRecordRepository,
-		private testStationRepository: TestStationRepository
+		private testStationRepository: TestStationRepository,
+		private testResultRepository: TestResultRepository
 	) {}
 
 	/**
@@ -349,7 +350,9 @@ class CertificateGenerationService {
 			payload.MSVA_DATA = { ...msvaData };
 		} else {
 			const odometerHistory =
-				vehicleType === VEHICLE_TYPES.TRL ? undefined : await this.getOdometerHistory(systemNumber);
+				vehicleType === VEHICLE_TYPES.TRL
+					? undefined
+					: await this.testResultRepository.getOdometerHistory(systemNumber);
 			const TrnObj = this.isValidForTrn(vehicleType, makeAndModel)
 				? await this.trailerRepository.getTrailerRegistrationObject(testResult.vin, makeAndModel.Make)
 				: undefined;
@@ -650,84 +653,6 @@ class CertificateGenerationService {
 			console.log('No techRecord found for weight details');
 			throw new HTTPError(500, 'No vehicle found for Roadworthiness test certificate!');
 		}
-	}
-
-	/**
-	 * Retrieves the odometer history for a given VIN from the Test Results microservice
-	 * @param systemNumber - systemNumber for which to retrieve odometer history
-	 */
-	public async getOdometerHistory(systemNumber: string) {
-		const config: IInvokeConfig = this.config.getInvokeConfig();
-		const invokeParams: InvocationRequest = {
-			FunctionName: config.functions.testResults.name,
-			InvocationType: 'RequestResponse',
-			LogType: 'Tail',
-			Payload: toUint8Array(
-				JSON.stringify({
-					httpMethod: 'GET',
-					path: `/test-results/${systemNumber}`,
-					pathParameters: {
-						systemNumber,
-					},
-				})
-			),
-		};
-
-		return this.lambdaClient
-			.invoke(invokeParams)
-			.then((response: InvocationResponse) => {
-				const payload: any = this.lambdaClient.validateInvocationResponse(response);
-				// TODO: convert to correct type
-				const testResults: any[] = JSON.parse(payload.body);
-
-				if (!testResults || testResults.length === 0) {
-					throw new HTTPError(400, `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`);
-				}
-				// Sort results by testEndTimestamp
-				testResults.sort((first: any, second: any): number => {
-					if (moment(first.testEndTimestamp).isBefore(second.testEndTimestamp)) {
-						return 1;
-					}
-
-					if (moment(first.testEndTimestamp).isAfter(second.testEndTimestamp)) {
-						return -1;
-					}
-
-					return 0;
-				});
-
-				// Remove the first result as it should be the current one.
-				testResults.shift();
-
-				// Set the array to only submitted tests (exclude cancelled)
-				const submittedTests = testResults.filter((testResult) => {
-					return testResult.testStatus === 'submitted';
-				});
-
-				const filteredTestResults = submittedTests
-					.filter(({ testTypes }) =>
-						testTypes?.some(
-							(testType: ITestType) =>
-								testType.testTypeClassification === 'Annual With Certificate' &&
-								(testType.testResult === 'pass' || testType.testResult === 'prs')
-						)
-					)
-					.slice(0, 3); // Only last three entries are used for the history.
-
-				return {
-					OdometerHistoryList: filteredTestResults.map((testResult) => {
-						return {
-							value: testResult.odometerReading,
-							unit: testResult.odometerReadingUnits,
-							date: moment(testResult.testEndTimestamp).format('DD.MM.YYYY'),
-						};
-					}),
-				};
-			})
-			.catch((error: ServiceException | Error) => {
-				console.log(error);
-				throw error;
-			});
 	}
 
 	/**

--- a/src/tech-record/TechRecordRepository.ts
+++ b/src/tech-record/TechRecordRepository.ts
@@ -51,4 +51,36 @@ export class TechRecordRepository {
 			return undefined;
 		}
 	};
+
+	/**
+	 * Used to return a subset of technical record information.
+	 * @param searchIdentifier
+	 */
+	public callSearchTechRecords = async (searchIdentifier: string) => {
+		const config: IInvokeConfig = this.config.getInvokeConfig();
+		const invokeParams: InvocationRequest = {
+			FunctionName: config.functions.techRecordsSearch.name,
+			InvocationType: 'RequestResponse',
+			LogType: 'Tail',
+			Payload: toUint8Array(
+				JSON.stringify({
+					httpMethod: 'GET',
+					path: `/v3/technical-records/search/${searchIdentifier}?searchCriteria=systemNumber`,
+					pathParameters: {
+						searchIdentifier,
+					},
+				})
+			),
+		};
+
+		try {
+			const lambdaResponse = await this.lambdaClient.invoke(invokeParams);
+			const res = await this.lambdaClient.validateInvocationResponse(lambdaResponse);
+			return JSON.parse(res.body);
+		} catch (e) {
+			console.log('Error searching technical records');
+			console.log(JSON.stringify(e));
+			return undefined;
+		}
+	};
 }

--- a/src/tech-record/TechRecordRepository.ts
+++ b/src/tech-record/TechRecordRepository.ts
@@ -1,0 +1,54 @@
+import { InvocationRequest } from '@aws-sdk/client-lambda';
+import { toUint8Array } from '@smithy/util-utf8';
+import { Service } from 'typedi';
+import { IInvokeConfig } from '../models';
+import { TechRecordGet, TechRecordType } from '../models/Types';
+import { LambdaService } from '../services/LambdaService';
+import { Configuration } from '../utils/Configuration';
+
+/*
+ * Enables management of technical records.
+ */
+@Service()
+export class TechRecordRepository {
+	private readonly config: Configuration = Configuration.getInstance();
+
+	constructor(private lambdaClient: LambdaService) {}
+
+	/**
+	 * Used to get a singular whole technical record.
+	 * @param systemNumber
+	 * @param createdTimestamp
+	 */
+	public callGetTechRecords = async <T extends TechRecordGet['techRecord_vehicleType']>(
+		systemNumber: string,
+		createdTimestamp: string
+	): Promise<TechRecordType<T> | undefined> => {
+		const config: IInvokeConfig = this.config.getInvokeConfig();
+		const invokeParams: InvocationRequest = {
+			FunctionName: config.functions.techRecords.name,
+			InvocationType: 'RequestResponse',
+			LogType: 'Tail',
+			Payload: toUint8Array(
+				JSON.stringify({
+					httpMethod: 'GET',
+					path: `/v3/technical-records/${systemNumber}/${createdTimestamp}`,
+					pathParameters: {
+						systemNumber,
+						createdTimestamp,
+					},
+				})
+			),
+		};
+
+		try {
+			const lambdaResponse = await this.lambdaClient.invoke(invokeParams);
+			const res = await this.lambdaClient.validateInvocationResponse(lambdaResponse);
+			return JSON.parse(res.body);
+		} catch (e) {
+			console.log('Error in get technical record');
+			console.log(JSON.stringify(e));
+			return undefined;
+		}
+	};
+}

--- a/src/test-result/TestResultRepository.ts
+++ b/src/test-result/TestResultRepository.ts
@@ -1,0 +1,90 @@
+import { InvocationRequest, InvocationResponse, ServiceException } from '@aws-sdk/client-lambda';
+import { toUint8Array } from '@smithy/util-utf8';
+import moment from 'moment';
+import { Service } from 'typedi';
+import { IInvokeConfig, ITestType } from '../models';
+import { ERRORS } from '../models/Enums';
+import { HTTPError } from '../models/HTTPError';
+import { LambdaService } from '../services/LambdaService';
+import { Configuration } from '../utils/Configuration';
+
+@Service()
+export class TestResultRepository {
+	private readonly config: Configuration = Configuration.getInstance();
+
+	constructor(private lambdaClient: LambdaService) {}
+
+	/**
+	 * Retrieves the odometer history for a given VIN from the Test Results microservice
+	 * @param systemNumber - systemNumber for which to retrieve odometer history
+	 */
+	public async getOdometerHistory(systemNumber: string) {
+		const config: IInvokeConfig = this.config.getInvokeConfig();
+		const invokeParams: InvocationRequest = {
+			FunctionName: config.functions.testResults.name,
+			InvocationType: 'RequestResponse',
+			LogType: 'Tail',
+			Payload: toUint8Array(
+				JSON.stringify({
+					httpMethod: 'GET',
+					path: `/test-results/${systemNumber}`,
+					pathParameters: {
+						systemNumber,
+					},
+				})
+			),
+		};
+
+		return this.lambdaClient
+			.invoke(invokeParams)
+			.then((response: InvocationResponse) => {
+				const payload: any = this.lambdaClient.validateInvocationResponse(response);
+				// TODO: convert to correct type
+				const testResults: any[] = JSON.parse(payload.body);
+
+				if (!testResults || testResults.length === 0) {
+					throw new HTTPError(400, `${ERRORS.LAMBDA_INVOCATION_BAD_DATA} ${JSON.stringify(payload)}.`);
+				}
+				// Sort results by testEndTimestamp
+				testResults.sort((first: any, second: any): number => {
+					if (moment(first.testEndTimestamp).isBefore(second.testEndTimestamp)) {
+						return 1;
+					}
+
+					if (moment(first.testEndTimestamp).isAfter(second.testEndTimestamp)) {
+						return -1;
+					}
+
+					return 0;
+				});
+
+				// Remove the first result as it should be the current one.
+				testResults.shift();
+
+				// Set the array to only submitted tests (exclude cancelled)
+				const submittedTests = testResults.filter((testResult) => testResult.testStatus === 'submitted');
+
+				const filteredTestResults = submittedTests
+					.filter(({ testTypes }) =>
+						testTypes?.some(
+							(testType: ITestType) =>
+								testType.testTypeClassification === 'Annual With Certificate' &&
+								(testType.testResult === 'pass' || testType.testResult === 'prs')
+						)
+					)
+					.slice(0, 3); // Only last three entries are used for the history.
+
+				return {
+					OdometerHistoryList: filteredTestResults.map((testResult) => ({
+						value: testResult.odometerReading,
+						unit: testResult.odometerReadingUnits,
+						date: moment(testResult.testEndTimestamp).format('DD.MM.YYYY'),
+					})),
+				};
+			})
+			.catch((error: ServiceException | Error) => {
+				console.log(error);
+				throw error;
+			});
+	}
+}

--- a/src/test-station/TestStationRepository.ts
+++ b/src/test-station/TestStationRepository.ts
@@ -1,0 +1,54 @@
+import { InvocationRequest, InvocationResponse } from '@aws-sdk/client-lambda';
+import { toUint8Array } from '@smithy/util-utf8';
+import { Service } from 'typedi';
+import { IInvokeConfig } from '../models';
+import { ITestStation } from '../models/ITestStations';
+import { LambdaService } from '../services/LambdaService';
+import { Configuration } from '../utils/Configuration';
+
+@Service()
+export class TestStationRepository {
+	private readonly config: Configuration = Configuration.getInstance();
+
+	constructor(private lambdaClient: LambdaService) {}
+
+	/**
+	 * Method to retrieve Test Station details from API
+	 * @returns a test station object
+	 */
+	public async getTestStation(testStationPNumber: string): Promise<ITestStation> {
+		const config: IInvokeConfig = this.config.getInvokeConfig();
+		const invokeParams: InvocationRequest = {
+			FunctionName: config.functions.testStations.name,
+			InvocationType: 'RequestResponse',
+			LogType: 'Tail',
+			Payload: toUint8Array(
+				JSON.stringify({
+					httpMethod: 'GET',
+					path: `/test-stations/${testStationPNumber}`,
+				})
+			),
+		};
+
+		let testStation: ITestStation = {} as ITestStation;
+		let retries = 0;
+
+		while (retries < 3) {
+			try {
+				// eslint-disable-next-line no-await-in-loop
+				const response: InvocationResponse = await this.lambdaClient.invoke(invokeParams);
+				const payload: any = this.lambdaClient.validateInvocationResponse(response);
+
+				testStation = JSON.parse(payload.body);
+
+				return testStation;
+			} catch (error) {
+				retries++;
+				console.error(
+					`There was an error retrieving the test station on attempt ${retries}: ${(error as Error).message}`
+				);
+			}
+		}
+		return testStation;
+	}
+}

--- a/src/trailer/IGetTrailerRegistrationResult.ts
+++ b/src/trailer/IGetTrailerRegistrationResult.ts
@@ -1,4 +1,4 @@
 export interface IGetTrailerRegistrationResult {
-  Trn?: string;
-  IsTrailer: boolean;
+	Trn?: string;
+	IsTrailer: boolean;
 }

--- a/src/trailer/IGetTrailerRegistrationResult.ts
+++ b/src/trailer/IGetTrailerRegistrationResult.ts
@@ -1,0 +1,4 @@
+export interface IGetTrailerRegistrationResult {
+  Trn?: string;
+  IsTrailer: boolean;
+}

--- a/src/trailer/TrailerRepository.ts
+++ b/src/trailer/TrailerRepository.ts
@@ -1,0 +1,72 @@
+import { Service } from "typedi";
+import { toUint8Array } from "@smithy/util-utf8";
+import { InvocationRequest } from "@aws-sdk/client-lambda";
+import { ITrailerRegistration, IInvokeConfig } from "../models";
+import { ERRORS } from "../models/Enums";
+import { HTTPError } from "../models/HTTPError";
+import { Configuration } from "../utils/Configuration";
+import { LambdaService } from "../services/LambdaService";
+import { IGetTrailerRegistrationResult } from "./IGetTrailerRegistrationResult";
+
+@Service()
+export class TrailerRepository {
+  private readonly config: Configuration = Configuration.getInstance();
+
+  constructor(private lambdaClient: LambdaService) {
+  }
+
+  /**
+   * To fetch trailer registration
+   * @param vin The vin of the trailer
+   * @param make The make of the trailer
+   * @returns A payload containing the TRN of the trailer and a boolean.
+   */
+  public async getTrailerRegistrationObject(vin: string, make: string): Promise<IGetTrailerRegistrationResult> {
+    const config: IInvokeConfig = this.config.getInvokeConfig();
+    const invokeParams: InvocationRequest = {
+      FunctionName: config.functions.trailerRegistration.name,
+      InvocationType: "RequestResponse",
+      LogType: "Tail",
+      Payload: toUint8Array(JSON.stringify({
+        httpMethod: "GET",
+        path: `/v1/trailers/${vin}`,
+        pathParameters: {
+          proxy: "/v1/trailers",
+        },
+        queryStringParameters: {
+          make,
+        },
+      })),
+    };
+    const response = await this.lambdaClient.invoke(invokeParams);
+    try {
+      if (!response.Payload || Buffer.from(response.Payload).toString() === "") {
+        throw new HTTPError(
+          500,
+          `${ERRORS.LAMBDA_INVOCATION_ERROR} ${response.StatusCode} ${ERRORS.EMPTY_PAYLOAD}`,
+        );
+      }
+      const payload: any = JSON.parse(Buffer.from(response.Payload).toString());
+      if (payload.statusCode === 404) {
+        console.debug(`vinOrChassisWithMake not found ${vin + make}`);
+        return { Trn: undefined, IsTrailer: true };
+      }
+      if (payload.statusCode >= 400) {
+        throw new HTTPError(
+          500,
+          `${ERRORS.LAMBDA_INVOCATION_ERROR} ${payload.statusCode} ${payload.body}`,
+        );
+      }
+      const trailerRegistration = JSON.parse(
+        payload.body,
+      ) as ITrailerRegistration;
+      return { Trn: trailerRegistration.trn, IsTrailer: true };
+    } catch (err) {
+      console.error(
+        `Error on fetching vinOrChassisWithMake ${vin + make}`,
+        err,
+      );
+      throw err;
+    }
+  }
+}

--- a/src/trailer/TrailerRepository.ts
+++ b/src/trailer/TrailerRepository.ts
@@ -1,72 +1,62 @@
-import { Service } from "typedi";
-import { toUint8Array } from "@smithy/util-utf8";
-import { InvocationRequest } from "@aws-sdk/client-lambda";
-import { ITrailerRegistration, IInvokeConfig } from "../models";
-import { ERRORS } from "../models/Enums";
-import { HTTPError } from "../models/HTTPError";
-import { Configuration } from "../utils/Configuration";
-import { LambdaService } from "../services/LambdaService";
-import { IGetTrailerRegistrationResult } from "./IGetTrailerRegistrationResult";
+import { InvocationRequest } from '@aws-sdk/client-lambda';
+import { toUint8Array } from '@smithy/util-utf8';
+import { Service } from 'typedi';
+import { IInvokeConfig, ITrailerRegistration } from '../models';
+import { ERRORS } from '../models/Enums';
+import { HTTPError } from '../models/HTTPError';
+import { LambdaService } from '../services/LambdaService';
+import { Configuration } from '../utils/Configuration';
+import { IGetTrailerRegistrationResult } from './IGetTrailerRegistrationResult';
 
 @Service()
 export class TrailerRepository {
-  private readonly config: Configuration = Configuration.getInstance();
+	private readonly config: Configuration = Configuration.getInstance();
 
-  constructor(private lambdaClient: LambdaService) {
-  }
+	constructor(private lambdaClient: LambdaService) {}
 
-  /**
-   * To fetch trailer registration
-   * @param vin The vin of the trailer
-   * @param make The make of the trailer
-   * @returns A payload containing the TRN of the trailer and a boolean.
-   */
-  public async getTrailerRegistrationObject(vin: string, make: string): Promise<IGetTrailerRegistrationResult> {
-    const config: IInvokeConfig = this.config.getInvokeConfig();
-    const invokeParams: InvocationRequest = {
-      FunctionName: config.functions.trailerRegistration.name,
-      InvocationType: "RequestResponse",
-      LogType: "Tail",
-      Payload: toUint8Array(JSON.stringify({
-        httpMethod: "GET",
-        path: `/v1/trailers/${vin}`,
-        pathParameters: {
-          proxy: "/v1/trailers",
-        },
-        queryStringParameters: {
-          make,
-        },
-      })),
-    };
-    const response = await this.lambdaClient.invoke(invokeParams);
-    try {
-      if (!response.Payload || Buffer.from(response.Payload).toString() === "") {
-        throw new HTTPError(
-          500,
-          `${ERRORS.LAMBDA_INVOCATION_ERROR} ${response.StatusCode} ${ERRORS.EMPTY_PAYLOAD}`,
-        );
-      }
-      const payload: any = JSON.parse(Buffer.from(response.Payload).toString());
-      if (payload.statusCode === 404) {
-        console.debug(`vinOrChassisWithMake not found ${vin + make}`);
-        return { Trn: undefined, IsTrailer: true };
-      }
-      if (payload.statusCode >= 400) {
-        throw new HTTPError(
-          500,
-          `${ERRORS.LAMBDA_INVOCATION_ERROR} ${payload.statusCode} ${payload.body}`,
-        );
-      }
-      const trailerRegistration = JSON.parse(
-        payload.body,
-      ) as ITrailerRegistration;
-      return { Trn: trailerRegistration.trn, IsTrailer: true };
-    } catch (err) {
-      console.error(
-        `Error on fetching vinOrChassisWithMake ${vin + make}`,
-        err,
-      );
-      throw err;
-    }
-  }
+	/**
+	 * To fetch trailer registration
+	 * @param vin The vin of the trailer
+	 * @param make The make of the trailer
+	 * @returns A payload containing the TRN of the trailer and a boolean.
+	 */
+	public async getTrailerRegistrationObject(vin: string, make: string): Promise<IGetTrailerRegistrationResult> {
+		const config: IInvokeConfig = this.config.getInvokeConfig();
+		const invokeParams: InvocationRequest = {
+			FunctionName: config.functions.trailerRegistration.name,
+			InvocationType: 'RequestResponse',
+			LogType: 'Tail',
+			Payload: toUint8Array(
+				JSON.stringify({
+					httpMethod: 'GET',
+					path: `/v1/trailers/${vin}`,
+					pathParameters: {
+						proxy: '/v1/trailers',
+					},
+					queryStringParameters: {
+						make,
+					},
+				})
+			),
+		};
+		const response = await this.lambdaClient.invoke(invokeParams);
+		try {
+			if (!response.Payload || Buffer.from(response.Payload).toString() === '') {
+				throw new HTTPError(500, `${ERRORS.LAMBDA_INVOCATION_ERROR} ${response.StatusCode} ${ERRORS.EMPTY_PAYLOAD}`);
+			}
+			const payload: any = JSON.parse(Buffer.from(response.Payload).toString());
+			if (payload.statusCode === 404) {
+				console.debug(`vinOrChassisWithMake not found ${vin + make}`);
+				return { Trn: undefined, IsTrailer: true };
+			}
+			if (payload.statusCode >= 400) {
+				throw new HTTPError(500, `${ERRORS.LAMBDA_INVOCATION_ERROR} ${payload.statusCode} ${payload.body}`);
+			}
+			const trailerRegistration = JSON.parse(payload.body) as ITrailerRegistration;
+			return { Trn: trailerRegistration.trn, IsTrailer: true };
+		} catch (err) {
+			console.error(`Error on fetching vinOrChassisWithMake ${vin + make}`, err);
+			throw err;
+		}
+	}
 }

--- a/tests/unit/CertificateGenerationService.unitTest.ts
+++ b/tests/unit/CertificateGenerationService.unitTest.ts
@@ -35,6 +35,7 @@ import testResultsResp from "../resources/test-results-response.json";
 import { S3BucketService } from "../../src/services/S3BucketService";
 import { S3BucketMockService } from "../models/S3BucketMockService";
 import { LambdaMockService } from "../models/LambdaMockService";
+import { TrailerRepository } from "../../src/trailer/TrailerRepository";
 
 jest.mock("@dvsa/cvs-feature-flags/profiles/vtx", () => ({
   getProfile: mockGetProfile
@@ -350,7 +351,8 @@ describe("Certificate Generation Service", () => {
         const certGenSvc = new CertificateGenerationService(
           // @ts-ignore
           null,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
         const getTechRecordSearchStub = sandbox
           .stub(certGenSvc, "callSearchTechRecords")
@@ -757,7 +759,8 @@ describe("Certificate Generation Service", () => {
       it("should log any exceptions flattening defects", () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
         const logSpy = jest.spyOn(console, "error");
 
@@ -783,7 +786,8 @@ describe("Certificate Generation Service", () => {
       it("should return a test station object if invoke is successful", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         LambdaService.prototype.invoke = jest.fn().mockResolvedValue({
@@ -802,7 +806,8 @@ describe("Certificate Generation Service", () => {
 
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         LambdaService.prototype.invoke = jest.fn().mockResolvedValue({
@@ -822,7 +827,8 @@ describe("Certificate Generation Service", () => {
       it("should return an empty object if test stations invoke is unsuccessful", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         LambdaService.prototype.invoke = jest.fn().mockResolvedValue({
@@ -839,7 +845,8 @@ describe("Certificate Generation Service", () => {
       it("should throw error if issue when parsing test station", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         LambdaService.prototype.invoke = jest.fn().mockResolvedValue({
@@ -861,7 +868,8 @@ describe("Certificate Generation Service", () => {
       it("should return an array of defects if invoke is successful", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         const mockDefects = defectsMock;
@@ -882,7 +890,8 @@ describe("Certificate Generation Service", () => {
 
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         LambdaService.prototype.invoke = jest.fn().mockResolvedValue({
@@ -902,7 +911,8 @@ describe("Certificate Generation Service", () => {
       it("should return an empty array if defects invoke is unsuccessful", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         LambdaService.prototype.invoke = jest.fn().mockResolvedValue({
@@ -919,7 +929,8 @@ describe("Certificate Generation Service", () => {
       it("should throw error if issue when parsing defects", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         const mockDefects: IDefectParent[] = [];
@@ -943,7 +954,8 @@ describe("Certificate Generation Service", () => {
       beforeEach(() => {
         certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
       });
       afterEach(() => {
@@ -1366,7 +1378,8 @@ describe("Certificate Generation Service", () => {
       it("should return true if test type id on test result exists in basic array", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         const ivaTestResult = cloneDeep(mockIvaTestResult);
@@ -1378,7 +1391,8 @@ describe("Certificate Generation Service", () => {
       it("should return false if test type id on test result does not exist in basic array", async () => {
         const certGenSvc = new CertificateGenerationService(
           null as any,
-          new LambdaService(new LambdaClient())
+          new LambdaService(new LambdaClient()),
+          Container.get(TrailerRepository),
         );
 
         const ivaTestResult = cloneDeep(mockIvaTestResult);

--- a/tests/unit/CertificateGenerationService.unitTest.ts
+++ b/tests/unit/CertificateGenerationService.unitTest.ts
@@ -48,6 +48,7 @@ describe("Certificate Generation Service", () => {
 
   const techRecordRepository = Container.get(TechRecordRepository);
   const callGetTechRecordSpy = jest.spyOn(techRecordRepository, "callGetTechRecords");
+  const callSearchTechRecordSpy = jest.spyOn(techRecordRepository, "callSearchTechRecords");
   Container.set(TechRecordRepository, techRecordRepository);
 
   const sandbox = sinon.createSandbox();
@@ -61,9 +62,7 @@ describe("Certificate Generation Service", () => {
       it("should return the record & only invoke the LambdaService once", async () => {
         const certGenSvc = Container.get(CertificateGenerationService);
 
-        const getTechRecordSearchStub = sandbox
-          .stub(certGenSvc, "callSearchTechRecords")
-          .resolves(techRecordsRwtSearch);
+        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
@@ -77,7 +76,7 @@ describe("Certificate Generation Service", () => {
         );
         expect(makeAndModel).toEqual({ Make: "STANLEY", Model: "AUTOTRL" });
         callGetTechRecordSpy.mockClear();
-        getTechRecordSearchStub.restore();
+        callSearchTechRecordSpy.mockClear();
       });
     });
 
@@ -87,9 +86,7 @@ describe("Certificate Generation Service", () => {
         it("should return the record & invoke the LambdaService twice", async () => {
           const certGenSvc = Container.get(CertificateGenerationService);
 
-          const getTechRecordSearchStub = sandbox
-            .stub(certGenSvc, "callSearchTechRecords")
-            .resolves(techRecordsRwtSearch);
+          callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
           const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
@@ -104,7 +101,7 @@ describe("Certificate Generation Service", () => {
           );
           expect(makeAndModel).toEqual({ Make: "STANLEY", Model: "AUTOTRL" });
           callGetTechRecordSpy.mockClear();
-          getTechRecordSearchStub.restore();
+          callSearchTechRecordSpy.mockClear();
         });
       }
     );
@@ -122,9 +119,7 @@ describe("Certificate Generation Service", () => {
 
           const certGenSvc = Container.get(CertificateGenerationService);
 
-          const getTechRecordSearchStub = sandbox
-            .stub(certGenSvc, "callSearchTechRecords")
-            .resolves(techRecordsRwtSearch);
+          callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
           const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
@@ -141,7 +136,7 @@ describe("Certificate Generation Service", () => {
           // expect(LambdaStub.calledTwice).toBeTruthy();
           expect(makeAndModel).toEqual({ Make: "STANLEY", Model: "AUTOTRL" });
           callGetTechRecordSpy.mockClear();
-          getTechRecordSearchStub.restore();
+          callSearchTechRecordSpy.mockClear();
         });
       }
     );
@@ -161,9 +156,7 @@ describe("Certificate Generation Service", () => {
 
           const certGenSvc = Container.get(CertificateGenerationService);
 
-          const getTechRecordSearchStub = sandbox
-            .stub(certGenSvc, "callSearchTechRecords")
-            .resolves(techRecordsRwtSearch);
+          callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
           const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
@@ -181,7 +174,7 @@ describe("Certificate Generation Service", () => {
           expect(LambdaStub.calledTwice).toBeFalsy();
           expect(makeAndModel).toEqual({ Make: "STANLEY", Model: "AUTOTRL" });
           callGetTechRecordSpy.mockClear();
-          getTechRecordSearchStub.restore();
+          callSearchTechRecordSpy.mockClear();
         });
       }
     );
@@ -192,9 +185,7 @@ describe("Certificate Generation Service", () => {
         it("should return the record & invoke the LambdaService four times", async () => {
           const certGenSvc = Container.get(CertificateGenerationService);
 
-          const getTechRecordSearchStub = sandbox
-            .stub(certGenSvc, "callSearchTechRecords")
-            .resolves(techRecordsRwtSearch);
+          callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
           const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
@@ -211,7 +202,7 @@ describe("Certificate Generation Service", () => {
           );
           expect(makeAndModel).toEqual({ Make: "STANLEY", Model: "AUTOTRL" });
           callGetTechRecordSpy.mockClear();
-          getTechRecordSearchStub.restore();
+          callSearchTechRecordSpy.mockClear();
         });
       }
     );
@@ -224,9 +215,7 @@ describe("Certificate Generation Service", () => {
 
         const certGenSvc = Container.get(CertificateGenerationService);
 
-        const getTechRecordSearchStub = sandbox
-          .stub(certGenSvc, "callSearchTechRecords")
-          .resolves(techRecordsRwtSearch);
+        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
@@ -247,7 +236,7 @@ describe("Certificate Generation Service", () => {
             "Unable to retrieve unique Tech Record for Test Result"
           );
           callGetTechRecordSpy.mockClear();
-          getTechRecordSearchStub.restore();
+          callSearchTechRecordSpy.mockClear();
         }
       });
     });
@@ -262,10 +251,7 @@ describe("Certificate Generation Service", () => {
 
           const certGenSvc = Container.get(CertificateGenerationService);
 
-          const getTechRecordSearchStub = sandbox
-            .stub(certGenSvc, "callSearchTechRecords")
-            .resolves(techRecordsRwtSearch);
-
+          callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
           const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
           callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -283,7 +269,7 @@ describe("Certificate Generation Service", () => {
               "Unable to retrieve unique Tech Record for Test Result"
             );
             callGetTechRecordSpy.mockClear();
-            getTechRecordSearchStub.restore();
+            callSearchTechRecordSpy.mockClear();
           }
         });
       }
@@ -293,10 +279,7 @@ describe("Certificate Generation Service", () => {
       it("should return make and model from chassis details", async () => {
         const certGenSvc = Container.get(CertificateGenerationService);
 
-        const getTechRecordSearchStub = sandbox
-          .stub(certGenSvc, "callSearchTechRecords")
-          .resolves(techRecordsSearchPsv);
-
+        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
         callGetTechRecordSpy.mockResolvedValue(techRecordsPsv as any);
@@ -310,7 +293,7 @@ describe("Certificate Generation Service", () => {
         expect(makeAndModel.Make).toBe("AEC");
         expect(makeAndModel.Model).toBe("RELIANCE");
         callGetTechRecordSpy.mockClear();
-        getTechRecordSearchStub.restore();
+        callSearchTechRecordSpy.mockClear();
       });
     });
 
@@ -318,9 +301,7 @@ describe("Certificate Generation Service", () => {
       it("should return make and model from not-chassis details", async () => {
         const certGenSvc = Container.get(CertificateGenerationService);
 
-        const getTechRecordSearchStub = sandbox
-          .stub(certGenSvc, "callSearchTechRecords")
-          .resolves(techRecordsRwtHgvSearch);
+        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
         callGetTechRecordSpy.mockResolvedValue(techRecordsRwtHgv as any);
 
         const testResultMock = {
@@ -332,7 +313,7 @@ describe("Certificate Generation Service", () => {
         expect(makeAndModel.Make).toBe("Isuzu");
         expect(makeAndModel.Model).toBe("FM");
         callGetTechRecordSpy.mockClear();
-        getTechRecordSearchStub.restore();
+        callSearchTechRecordSpy.mockClear();
       });
     });
   });

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -51,6 +51,7 @@ describe("cert-gen", () => {
 
   const techRecordRepository = Container.get(TechRecordRepository);
   const callGetTechRecordSpy = jest.spyOn(techRecordRepository, "callGetTechRecords");
+  const callSearchTechRecordSpy = jest.spyOn(techRecordRepository, "callSearchTechRecords");
   Container.set(TechRecordRepository, techRecordRepository);
 
   const certificateGenerationService = Container.get(CertificateGenerationService);
@@ -134,9 +135,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -146,7 +145,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -198,10 +197,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -211,7 +207,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -271,9 +267,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -284,7 +278,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -318,9 +312,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
 
@@ -352,7 +344,7 @@ describe("cert-gen", () => {
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -414,9 +406,7 @@ describe("cert-gen", () => {
                             bucketName: `cvs-signature-${process.env.BUCKET}`,
                             files: ["1.base64"],
                         });
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -426,7 +416,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -438,9 +428,7 @@ describe("cert-gen", () => {
                 "and the generated payload is used to call the MOT service",
                 () => {
                     it("successfully generate a certificate", async () => {
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -458,7 +446,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -524,9 +512,7 @@ describe("cert-gen", () => {
                                 Date: "14.12.2022"
                             }
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -536,7 +522,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -590,9 +576,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -602,7 +586,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -673,9 +657,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                          .stub(certificateGenerationService, "callSearchTechRecords")
-                          .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
@@ -684,7 +666,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
 
@@ -743,9 +725,7 @@ describe("cert-gen", () => {
                                 },
                             };
 
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtHgvSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -755,7 +735,7 @@ describe("cert-gen", () => {
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -815,9 +795,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -827,7 +805,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -886,9 +864,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -898,7 +874,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -941,9 +917,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -953,7 +927,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -996,9 +970,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1008,7 +980,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1051,9 +1023,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1063,7 +1033,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1106,9 +1076,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1118,7 +1086,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1177,9 +1145,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1189,7 +1155,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1248,9 +1214,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1260,7 +1224,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1320,9 +1284,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1332,7 +1294,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1393,9 +1355,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1405,7 +1365,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1464,9 +1424,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1481,7 +1439,7 @@ describe("cert-gen", () => {
                                 expect(defectSpy).not.toHaveBeenCalled();
                                 expect(flattenSpy).not.toHaveBeenCalled();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1551,9 +1509,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1563,7 +1519,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1606,9 +1562,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         // @ts-ignore
@@ -1631,7 +1585,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1702,9 +1656,7 @@ describe("cert-gen", () => {
                             bucketName: `cvs-signature-${process.env.BUCKET}`,
                             files: ["1.base64"],
                         });
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1715,7 +1667,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -1727,9 +1679,7 @@ describe("cert-gen", () => {
                 "and the generated payload is used to call the MOT service",
                 () => {
                     it("successfully generate a certificate", async () => {
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1747,7 +1697,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -1827,9 +1777,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1839,7 +1787,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1899,9 +1847,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1911,7 +1857,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -1970,9 +1916,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -1982,7 +1926,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2042,9 +1986,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2054,7 +1996,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2116,9 +2058,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2128,7 +2068,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2194,9 +2134,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2206,7 +2144,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2274,9 +2212,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2286,7 +2222,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2364,9 +2300,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2376,7 +2310,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2438,9 +2372,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2450,7 +2382,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2520,9 +2452,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2532,7 +2462,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2596,9 +2526,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2608,7 +2536,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2676,9 +2604,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2688,7 +2614,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -2731,9 +2657,7 @@ describe("cert-gen", () => {
                             }
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2743,7 +2667,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -2789,9 +2713,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2801,7 +2723,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -2846,9 +2768,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2858,7 +2778,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -2904,9 +2824,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2916,7 +2834,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -2964,9 +2882,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -2976,7 +2892,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -3028,9 +2944,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3040,7 +2954,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -3094,9 +3008,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3106,7 +3018,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -3170,9 +3082,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3182,7 +3092,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -3237,9 +3147,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3249,7 +3157,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -3313,9 +3221,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3325,7 +3231,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -3378,9 +3284,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3390,7 +3294,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -3453,9 +3357,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3465,14 +3367,13 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
             });
 
             context("should return Certificate Data without any Welsh defect arrays populated", () => {
-                let getTechRecordSearchStub: any;
                 let techRecordsPsvStub: any;
                 const expectedResultEnglish: any = {
                     FAIL_DATA: {
@@ -3534,9 +3435,7 @@ describe("cert-gen", () => {
                     Watermark: "NOT VALID"
                 };
                 beforeEach(() => {
-                    getTechRecordSearchStub = sandbox
-                        .stub(certificateGenerationService, "callSearchTechRecords")
-                        .resolves(techRecordsSearchPsv);
+                    callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                     techRecordsPsvStub = cloneDeep(psvFailWithDefects);
                     callGetTechRecordSpy.mockResolvedValue(techRecordsPsv as any);
@@ -3544,7 +3443,7 @@ describe("cert-gen", () => {
 
                 afterEach(() => {
                     callGetTechRecordSpy.mockClear();
-                    getTechRecordSearchStub.restore();
+                    callSearchTechRecordSpy.mockClear();
                 });
                 it("should return a VTP30W payload with the MajorDefectsWelsh array populated", async () => {
                     return await certificateGenerationService
@@ -3656,9 +3555,7 @@ describe("cert-gen", () => {
                     Watermark: "NOT VALID"
                 };
                 beforeEach(() => {
-                    getTechRecordSearchStub = sandbox
-                        .stub(certificateGenerationService, "callSearchTechRecords")
-                        .resolves(techRecordsSearchPsv);
+                    callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                     techRecordsPsvStub = cloneDeep(psvFailWithDefects);
                     callGetTechRecordSpy.mockResolvedValue(techRecordsPsv as any);
@@ -3666,7 +3563,7 @@ describe("cert-gen", () => {
 
                 afterEach(() => {
                   callGetTechRecordSpy.mockClear();
-                  getTechRecordSearchStub.restore();
+                  callSearchTechRecordSpy.mockClear();
                 });
 
 
@@ -3776,9 +3673,7 @@ describe("cert-gen", () => {
                                 },
                                 Watermark: "NOT VALID"
                             };
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtHgvSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3788,7 +3683,7 @@ describe("cert-gen", () => {
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         }
                     );
@@ -3853,9 +3748,7 @@ describe("cert-gen", () => {
                                 },
                                 Watermark: "NOT VALID"
                             };
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtHgvSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3865,7 +3758,7 @@ describe("cert-gen", () => {
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -3966,9 +3859,7 @@ describe("cert-gen", () => {
                             Watermark: "NOT VALID"
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -3978,7 +3869,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -4076,9 +3967,7 @@ describe("cert-gen", () => {
                             },
                             Watermark: "NOT VALID"
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseMock as any);
@@ -4088,7 +3977,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -4189,9 +4078,7 @@ describe("cert-gen", () => {
                             Watermark: "NOT VALID"
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -4201,7 +4088,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -4300,9 +4187,7 @@ describe("cert-gen", () => {
                             Watermark: "NOT VALID"
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -4312,7 +4197,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -4407,9 +4292,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -4419,7 +4302,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -4474,9 +4357,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         // @ts-ignore
@@ -4500,7 +4381,7 @@ describe("cert-gen", () => {
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -4603,9 +4484,7 @@ describe("cert-gen", () => {
                             files: ["1.base64"],
                         });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -4616,7 +4495,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 resBody = payload.body;
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -4628,9 +4507,7 @@ describe("cert-gen", () => {
                 "and the generated payload is used to call the MOT service",
                 () => {
                     it("successfully generate a certificate", async () => {
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsSearchPsv);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -4648,7 +4525,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -5390,9 +5267,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5403,7 +5278,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -5437,9 +5312,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         // @ts-ignore
@@ -5462,7 +5335,7 @@ describe("cert-gen", () => {
                             getOdometerHistoryStub.restore();
                             // getVehicleMakeAndModelStub.restore();
                             callGetTechRecordSpy.mockClear();
-                            getTechRecordSearchStub.restore();
+                            callSearchTechRecordSpy.mockClear();
                           });
                       });
                     });
@@ -5525,9 +5398,7 @@ describe("cert-gen", () => {
                             files: ["1.base64"],
                         });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5538,7 +5409,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -5550,9 +5421,7 @@ describe("cert-gen", () => {
                 "and the generated payload is used to call the MOT service",
                 () => {
                     it("successfully generate a certificate", async () => {
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5570,7 +5439,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -5676,9 +5545,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5688,7 +5555,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -5743,9 +5610,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         // @ts-ignore
@@ -5768,7 +5633,7 @@ describe("cert-gen", () => {
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -5870,9 +5735,7 @@ describe("cert-gen", () => {
                             bucketName: `cvs-signature-${process.env.BUCKET}`,
                             files: ["1.base64"],
                         });
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5883,7 +5746,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 resBody = payload.body;
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -5895,9 +5758,7 @@ describe("cert-gen", () => {
                 "and the generated payload is used to call the MOT service",
                 () => {
                     it("successfully generate a certificate", async () => {
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5915,7 +5776,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -5984,9 +5845,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -5996,7 +5855,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -6039,9 +5898,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         // @ts-ignore
@@ -6064,7 +5921,7 @@ describe("cert-gen", () => {
                               expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                           });
                     });
                 });
@@ -6135,9 +5992,7 @@ describe("cert-gen", () => {
                             bucketName: `cvs-signature-${process.env.BUCKET}`,
                             files: ["1.base64"],
                         });
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6147,7 +6002,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -6159,9 +6014,7 @@ describe("cert-gen", () => {
                 "and the generated payload is used to call the MOT service",
                 () => {
                     it("successfully generate a certificate", async () => {
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6179,7 +6032,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -6225,9 +6078,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6237,7 +6088,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -6272,9 +6123,7 @@ describe("cert-gen", () => {
                                 ImageData: null,
                             },
                         };
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         // @ts-ignore
@@ -6298,7 +6147,7 @@ describe("cert-gen", () => {
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -6345,9 +6194,7 @@ describe("cert-gen", () => {
                             files: ["1.base64"],
                         });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6358,7 +6205,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -6371,9 +6218,7 @@ describe("cert-gen", () => {
                 () => {
                     it("successfully generate a certificate", async () => {
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6389,7 +6234,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -6444,9 +6289,7 @@ describe("cert-gen", () => {
                             )
                             .resolves({ Trn: undefined, IsTrailer: true });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6456,7 +6299,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                                 getTrailerRegistrationStub.restore();
@@ -6514,9 +6357,7 @@ describe("cert-gen", () => {
                             )
                             .rejects({ statusCode: 500, body: "an error occured" });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6526,7 +6367,7 @@ describe("cert-gen", () => {
                             .catch((err: any) => {
                                 expect(err.statusCode).toEqual(500);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                                 getTrailerRegistrationStub.restore();
@@ -6603,9 +6444,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6615,7 +6454,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -6673,9 +6512,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         // @ts-ignore
@@ -6698,7 +6535,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -6769,9 +6606,7 @@ describe("cert-gen", () => {
                             files: ["1.base64"],
                         });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6784,7 +6619,7 @@ describe("cert-gen", () => {
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -6795,9 +6630,7 @@ describe("cert-gen", () => {
                 () => {
                     it("successfully generate a certificate", async () => {
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6813,7 +6646,7 @@ describe("cert-gen", () => {
                                     total: 2,
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -6867,9 +6700,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -6879,7 +6710,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
 
                     });
@@ -6925,9 +6756,7 @@ describe("cert-gen", () => {
                             },
                         };
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         // @ts-ignore
@@ -6950,7 +6779,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // getVehicleMakeAndModelStub.restore();
                             });
                     });
@@ -7007,9 +6836,7 @@ describe("cert-gen", () => {
                             files: ["1.base64"],
                         });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7019,7 +6846,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                             });
@@ -7032,9 +6859,7 @@ describe("cert-gen", () => {
                 () => {
                     it("successfully generate a certificate", async () => {
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7051,7 +6876,7 @@ describe("cert-gen", () => {
 
                                 });
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 }
@@ -7106,9 +6931,7 @@ describe("cert-gen", () => {
                             )
                             .resolves({ Trn: undefined, IsTrailer: true });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7117,7 +6940,7 @@ describe("cert-gen", () => {
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 callGetTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -7158,9 +6981,7 @@ describe("cert-gen", () => {
                             )
                         );
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         delete expectedResult.techRecord_make;
@@ -7173,7 +6994,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                             });
                     });
                 });
@@ -7210,9 +7031,7 @@ describe("cert-gen", () => {
                             files: ["1.base64"],
                         });
 
-                        const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtSearch);
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7223,7 +7042,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 // getTechRecordStub.restore();
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                                 S3BucketMockService.buckets.pop();
                             });
                     });
@@ -7248,9 +7067,7 @@ describe("cert-gen", () => {
                                 docGenRwt[0]
                             );
 
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7260,7 +7077,7 @@ describe("cert-gen", () => {
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -7277,9 +7094,7 @@ describe("cert-gen", () => {
                                 files: ["1.base64"],
                             });
 
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7290,7 +7105,7 @@ describe("cert-gen", () => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
                                     S3BucketMockService.buckets.pop();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -7307,9 +7122,7 @@ describe("cert-gen", () => {
                     testResult.vin = "GYFC26269R240355";
                     testResult.vrm = "NKPILNCN";
 
-                    const getTechRecordSearchStub = sandbox
-                        .stub(certificateGenerationService, "callSearchTechRecords")
-                        .resolves(techRecordsRwtSearch);
+                    callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                     const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                     callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7320,7 +7133,7 @@ describe("cert-gen", () => {
                         .then((response: any) => {
                             expect(response.certificateType).toEqual("RWT");
                             callGetTechRecordSpy.mockClear();
-                            getTechRecordSearchStub.restore();
+                            callSearchTechRecordSpy.mockClear();
                         });
                 });
             }
@@ -7340,9 +7153,7 @@ describe("cert-gen", () => {
                             const expectedResult: ICertificatePayload = cloneDeep(
                                 docGenRwt[4]
                             );
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7351,7 +7162,7 @@ describe("cert-gen", () => {
                               .generatePayload(testResult);
                             expect(payload).toEqual(expectedResult);
                             callGetTechRecordSpy.mockClear();
-                            getTechRecordSearchStub.restore();
+                            callSearchTechRecordSpy.mockClear();
                         });
                     });
 
@@ -7367,9 +7178,7 @@ describe("cert-gen", () => {
                                 files: ["1.base64"],
                             });
 
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7379,7 +7188,7 @@ describe("cert-gen", () => {
                             expect(payload).toEqual(expectedResult);
                             S3BucketMockService.buckets.pop();
                             callGetTechRecordSpy.mockClear();
-                            getTechRecordSearchStub.restore();
+                            callSearchTechRecordSpy.mockClear();
                         });
                     });
                 });
@@ -7458,9 +7267,7 @@ describe("cert-gen", () => {
                                 "Watermark": "NOT VALID"
                             };
 
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7470,7 +7277,7 @@ describe("cert-gen", () => {
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -7537,9 +7344,7 @@ describe("cert-gen", () => {
                                 "Watermark": "NOT VALID"
                             };
 
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7549,7 +7354,7 @@ describe("cert-gen", () => {
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -7560,9 +7365,7 @@ describe("cert-gen", () => {
                                     docGenIva30[0]
                                 );
 
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7572,7 +7375,7 @@ describe("cert-gen", () => {
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
                                         callGetTechRecordSpy.mockClear();
-                                        getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         });
@@ -7589,9 +7392,7 @@ describe("cert-gen", () => {
                                     files: ["1.base64"],
                                 });
 
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7602,7 +7403,7 @@ describe("cert-gen", () => {
                                         expect(payload).toEqual(expectedResult);
                                         callGetTechRecordSpy.mockClear();
                                         S3BucketMockService.buckets.pop();
-                                        getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         });
@@ -7611,9 +7412,7 @@ describe("cert-gen", () => {
                             "and the generated payload is used to call the MOT service",
                             () => {
                                 it("successfully generate a certificate", async () => {
-                                    const getTechRecordSearchStub = sandbox
-                                        .stub(certificateGenerationService, "callSearchTechRecords")
-                                        .resolves(techRecordsRwtSearch);
+                                    callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                     const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                     callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7631,7 +7430,7 @@ describe("cert-gen", () => {
                                                 total: 2,
                                             });
                                             callGetTechRecordSpy.mockClear();
-                                            getTechRecordSearchStub.restore();
+                                            callSearchTechRecordSpy.mockClear();
                                         });
                                 });
                             }
@@ -7712,9 +7511,7 @@ describe("cert-gen", () => {
                                     "Watermark": "NOT VALID"
                                 };
 
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7724,7 +7521,7 @@ describe("cert-gen", () => {
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
                                         callGetTechRecordSpy.mockClear();
-                                        getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         });
@@ -7791,9 +7588,7 @@ describe("cert-gen", () => {
                                     "Watermark": "NOT VALID"
                                 };
 
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7803,7 +7598,7 @@ describe("cert-gen", () => {
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
                                         callGetTechRecordSpy.mockClear();
-                                        getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         });
@@ -7814,9 +7609,7 @@ describe("cert-gen", () => {
                                     docGenMsva30[0]
                                 );
 
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7826,7 +7619,7 @@ describe("cert-gen", () => {
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
                                         callGetTechRecordSpy.mockClear();
-                                        getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         });
@@ -7843,9 +7636,7 @@ describe("cert-gen", () => {
                                     files: ["1.base64"],
                                 });
 
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7856,7 +7647,7 @@ describe("cert-gen", () => {
                                         expect(payload).toEqual(expectedResult);
                                         callGetTechRecordSpy.mockClear();
                                         S3BucketMockService.buckets.pop();
-                                                            getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         });
@@ -7865,9 +7656,7 @@ describe("cert-gen", () => {
                             "and the generated payload is used to call the MOT service",
                             () => {
                                 it("successfully generate a certificate", async () => {
-                                    const getTechRecordSearchStub = sandbox
-                                        .stub(certificateGenerationService, "callSearchTechRecords")
-                                        .resolves(techRecordsRwtSearch);
+                                    callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                                     const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                     callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7885,7 +7674,7 @@ describe("cert-gen", () => {
                                                 total: 2,
                                             });
                                             callGetTechRecordSpy.mockClear();
-                                            getTechRecordSearchStub.restore();
+                                            callSearchTechRecordSpy.mockClear();
                                         });
                                 });
                             }
@@ -7909,9 +7698,7 @@ describe("cert-gen", () => {
                 context("when uploading a certificate", () => {
                     context("and the S3 bucket exists and is accesible", () => {
                         it("should successfully upload the certificate", async () => {
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7932,7 +7719,7 @@ describe("cert-gen", () => {
                                         `${process.env.BRANCH}/${generatedCertificateResponse.fileName}`
                                     );
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                     S3BucketMockService.buckets.pop();
                                 });
                         });
@@ -7940,9 +7727,7 @@ describe("cert-gen", () => {
 
                     context("and the S3 bucket does not exist or is not accesible", () => {
                         it("should throw an error", async () => {
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
@@ -7957,7 +7742,7 @@ describe("cert-gen", () => {
                                 .catch((error: any) => {
                                     expect(error).toBeInstanceOf(Error);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -35,6 +35,7 @@ import { LambdaService } from "../../src/services/LambdaService";
 import { TrailerRepository } from "../../src/trailer/TrailerRepository";
 import { TechRecordRepository } from "../../src/tech-record/TechRecordRepository";
 import { TestResultRepository } from "../../src/test-result/TestResultRepository";
+import { DefectRepository } from "../../src/defect/DefectRepository";
 
 const sandbox = sinon.createSandbox();
 
@@ -1432,17 +1433,21 @@ describe("cert-gen", () => {
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
-                        const defectSpy = jest.spyOn(certificateGenerationService, "getDefectTranslations");
+                        const defectRepository = Container.get(DefectRepository);
+                        const getDefectTranslationsSpy = jest.spyOn(defectRepository, "getDefectTranslations");
+                        Container.set(DefectRepository, defectRepository);
+
                         const flattenSpy = jest.spyOn(certificateGenerationService, "flattenDefectsFromApi");
 
                         return await certificateGenerationService
                             .generatePayload(psvTestResultWithMinorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                expect(defectSpy).not.toHaveBeenCalled();
+                                expect(getDefectTranslationsSpy).not.toHaveBeenCalled();
                                 expect(flattenSpy).not.toHaveBeenCalled();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
+                                getDefectTranslationsSpy.mockRestore();
                             });
                     });
                 });

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -34,6 +34,7 @@ import { S3BucketService } from "../../src/services/S3BucketService";
 import { LambdaService } from "../../src/services/LambdaService";
 import { TrailerRepository } from "../../src/trailer/TrailerRepository";
 import { TechRecordRepository } from "../../src/tech-record/TechRecordRepository";
+import { TestResultRepository } from "../../src/test-result/TestResultRepository";
 
 const sandbox = sinon.createSandbox();
 
@@ -53,6 +54,10 @@ describe("cert-gen", () => {
   const callGetTechRecordSpy = jest.spyOn(techRecordRepository, "callGetTechRecords");
   const callSearchTechRecordSpy = jest.spyOn(techRecordRepository, "callSearchTechRecords");
   Container.set(TechRecordRepository, techRecordRepository);
+
+  const testResultRepository = Container.get(TestResultRepository);
+  let callGetOdometerSpy = jest.spyOn(testResultRepository, 'getOdometerHistory');
+  Container.set(TestResultRepository, testResultRepository);
 
   const certificateGenerationService = Container.get(CertificateGenerationService);
 
@@ -74,9 +79,12 @@ describe("cert-gen", () => {
         };
 
         mockGetProfile.mockReturnValue(Promise.resolve(featureFlags));
+
+        callGetOdometerSpy = jest.spyOn(testResultRepository, "getOdometerHistory");
     });
     afterEach(() => {
         sandbox.restore();
+        callGetOdometerSpy.mockRestore();
     });
     context("CertificateGenerationService", () => {
         LambdaMockService.populateFunctions();
@@ -324,12 +332,7 @@ describe("cert-gen", () => {
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         // Stub CertificateGenerationService getVehicleMakeAndModel method to return undefined value.
                         // const getVehicleMakeAndModelStub = sandbox
                         //     .stub(
@@ -341,7 +344,7 @@ describe("cert-gen", () => {
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
@@ -1573,17 +1576,12 @@ describe("cert-gen", () => {
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
                             });
@@ -4368,17 +4366,12 @@ describe("cert-gen", () => {
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
@@ -5322,17 +5315,12 @@ describe("cert-gen", () => {
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                          .stub(
-                              CertificateGenerationService.prototype,
-                              "getOdometerHistory"
-                          )
-                          .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                           .generatePayload(testResult)
                           .then((payload: any) => {
                             expect(payload).toEqual(expectedResult);
-                            getOdometerHistoryStub.restore();
+                            callGetOdometerSpy.mockClear();
                             // getVehicleMakeAndModelStub.restore();
                             callGetTechRecordSpy.mockClear();
                             callSearchTechRecordSpy.mockClear();
@@ -5620,17 +5608,12 @@ describe("cert-gen", () => {
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                           .generatePayload(testResult)
                           .then((payload: any) => {
                               expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
@@ -5908,18 +5891,13 @@ describe("cert-gen", () => {
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         // Stub CertificateGenerationService getVehicleMakeAndModel method to return undefined value.
                         return await certificateGenerationService
                           .generatePayload(testResult)
                           .then((payload: any) => {
                               expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
                           });
@@ -6134,17 +6112,12 @@ describe("cert-gen", () => {
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 // getVehicleMakeAndModelStub.restore();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
@@ -6523,17 +6496,12 @@ describe("cert-gen", () => {
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
                             });
@@ -6767,17 +6735,12 @@ describe("cert-gen", () => {
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
-                        const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                        callGetOdometerSpy.mockResolvedValue(undefined as any);
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
+                                callGetOdometerSpy.mockClear();
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
                                 // getVehicleMakeAndModelStub.restore();

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -32,6 +32,7 @@ import techRecordsRwt from "../resources/tech-records-response-rwt.json";
 import techRecordsSearchPsv from "../resources/tech-records-response-search-PSV.json";
 import { S3BucketService } from "../../src/services/S3BucketService";
 import { LambdaService } from "../../src/services/LambdaService";
+import { TrailerRepository } from "../../src/trailer/TrailerRepository";
 
 const sandbox = sinon.createSandbox();
 
@@ -6589,7 +6590,7 @@ describe("cert-gen", () => {
 
                         const getTrailerRegistrationStub = sandbox
                             .stub(
-                                CertificateGenerationService.prototype,
+                                TrailerRepository.prototype,
                                 "getTrailerRegistrationObject"
                             )
                             .resolves({ Trn: undefined, IsTrailer: true });
@@ -6661,7 +6662,7 @@ describe("cert-gen", () => {
 
                         const getTrailerRegistrationStub = sandbox
                             .stub(
-                                CertificateGenerationService.prototype,
+                                TrailerRepository.prototype,
                                 "getTrailerRegistrationObject"
                             )
                             .rejects({ statusCode: 500, body: "an error occured" });
@@ -7271,7 +7272,7 @@ describe("cert-gen", () => {
                         };
                         const getTrailerRegistrationStub = sandbox
                             .stub(
-                                CertificateGenerationService.prototype,
+                                TrailerRepository.prototype,
                                 "getTrailerRegistrationObject"
                             )
                             .resolves({ Trn: undefined, IsTrailer: true });

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata';
+import "reflect-metadata";
 
 /* eslint-disable import/first */
 const mockGetProfile = jest.fn();
@@ -33,6 +33,7 @@ import techRecordsSearchPsv from "../resources/tech-records-response-search-PSV.
 import { S3BucketService } from "../../src/services/S3BucketService";
 import { LambdaService } from "../../src/services/LambdaService";
 import { TrailerRepository } from "../../src/trailer/TrailerRepository";
+import { TechRecordRepository } from "../../src/tech-record/TechRecordRepository";
 
 const sandbox = sinon.createSandbox();
 
@@ -45,10 +46,14 @@ describe("cert-gen", () => {
         expect(true).toBe(true);
     });
 
-    Container.set(S3BucketService, new S3BucketMockService());
-    Container.set(LambdaService, new LambdaMockService());
-  
-    const certificateGenerationService = Container.get(CertificateGenerationService);
+  Container.set(S3BucketService, new S3BucketMockService());
+  Container.set(LambdaService, new LambdaMockService());
+
+  const techRecordRepository = Container.get(TechRecordRepository);
+  const callGetTechRecordSpy = jest.spyOn(techRecordRepository, "callGetTechRecords");
+  Container.set(TechRecordRepository, techRecordRepository);
+
+  const certificateGenerationService = Container.get(CertificateGenerationService);
 
     beforeAll(() => {
         jest.setTimeout(10000);
@@ -134,15 +139,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -201,15 +204,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult2)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -275,16 +276,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -329,9 +328,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
@@ -354,7 +351,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -422,15 +419,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -448,9 +443,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -464,7 +457,7 @@ describe("cert-gen", () => {
                                     current: 1,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -536,15 +529,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResultWithTestHistoryForResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -604,15 +595,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResultWithTestHistoryForSomeotherResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -685,18 +674,16 @@ describe("cert-gen", () => {
                         };
 
                         const getTechRecordSearchStub = sandbox
-                            .stub(certificateGenerationService, "callSearchTechRecords")
-                            .resolves(techRecordsRwtHgvSearch);
+                          .stub(certificateGenerationService, "callSearchTechRecords")
+                          .resolves(techRecordsRwtHgvSearch);
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvTestResultWithMinorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -761,15 +748,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtHgvSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(hgvTestResultWithMinorDefect, true)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -835,15 +820,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvTestResultWithAdvisoryDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -908,15 +891,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return certificateGenerationService
                             .generatePayload(hgvTestResultWithAdvisoryDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -965,15 +946,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlTestResultWithMinorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1022,15 +1001,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlTestResultWithMinorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1079,15 +1056,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlTestResultWithAdvisoryDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1136,15 +1111,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return certificateGenerationService
                             .generatePayload(trlTestResultWithAdvisoryDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1209,15 +1182,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(psvTestResultWithMinorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1282,15 +1253,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return certificateGenerationService
                             .generatePayload(psvTestResultWithMinorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1356,15 +1325,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(psvTestResultWithAdvisoryDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1431,15 +1398,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return certificateGenerationService
                             .generatePayload(psvTestResultWithAdvisoryDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1504,9 +1469,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         const defectSpy = jest.spyOn(certificateGenerationService, "getDefectTranslations");
                         const flattenSpy = jest.spyOn(certificateGenerationService, "flattenDefectsFromApi");
@@ -1517,7 +1480,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 expect(defectSpy).not.toHaveBeenCalled();
                                 expect(flattenSpy).not.toHaveBeenCalled();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1593,15 +1556,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1654,9 +1615,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
@@ -1671,7 +1630,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1748,16 +1707,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -1775,9 +1732,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -1791,7 +1746,7 @@ describe("cert-gen", () => {
                                     current: 2,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1877,15 +1832,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithDangerousDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -1951,15 +1904,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithDangerousDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2024,15 +1975,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithMajorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2098,15 +2047,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithMajorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2174,15 +2121,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithDangerousAndMajorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2254,15 +2199,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithDangerousAndMajorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2336,15 +2279,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithAdvisoryMinorDangerousMajorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2428,15 +2369,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithAdvisoryMinorDangerousMajorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2504,15 +2443,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithDangerousDefectMajorRectified)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2588,15 +2525,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithDangerousDefectMajorRectified, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2666,15 +2601,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithMajorDefectDangerousRectified)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2748,15 +2681,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvFailWithMajorDefectDangerousRectified, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -2805,15 +2736,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithDangerousDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -2865,15 +2794,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithDangerousDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -2924,15 +2851,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithMajorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -2984,15 +2909,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithMajorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -3046,15 +2969,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithDangerousAndMajorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -3112,15 +3033,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithDangerousAndMajorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -3180,15 +3099,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithAdvisoryMinorDangerousMajorDefect)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -3258,15 +3175,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithAdvisoryMinorDangerousMajorDefect, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -3327,15 +3242,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithDangerousDefectMajorRectified)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -3405,15 +3318,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithDangerousDefectMajorRectified, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -3472,15 +3383,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithMajorDefectDangerousRectified)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -3549,15 +3458,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(trlFailWithMajorDefectDangerousRectified, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -3566,7 +3473,6 @@ describe("cert-gen", () => {
 
             context("should return Certificate Data without any Welsh defect arrays populated", () => {
                 let getTechRecordSearchStub: any;
-                let getTechRecordStub: any;
                 let techRecordsPsvStub: any;
                 const expectedResultEnglish: any = {
                     FAIL_DATA: {
@@ -3633,13 +3539,11 @@ describe("cert-gen", () => {
                         .resolves(techRecordsSearchPsv);
 
                     techRecordsPsvStub = cloneDeep(psvFailWithDefects);
-                    getTechRecordStub = sandbox
-                        .stub(certificateGenerationService, "callGetTechRecords")
-                        .resolves((techRecordsPsv) as any);
+                    callGetTechRecordSpy.mockResolvedValue(techRecordsPsv as any);
                 });
 
                 afterEach(() => {
-                    getTechRecordStub.restore();
+                    callGetTechRecordSpy.mockClear();
                     getTechRecordSearchStub.restore();
                 });
                 it("should return a VTP30W payload with the MajorDefectsWelsh array populated", async () => {
@@ -3680,7 +3584,6 @@ describe("cert-gen", () => {
             });
             context("should return certificate data with welsh defects array", () => {
                 let getTechRecordSearchStub: any;
-                let getTechRecordStub: any;
                 let techRecordsPsvStub: any;
                 const expectedResultWelsh: any = {
                     FAIL_DATA: {
@@ -3758,14 +3661,12 @@ describe("cert-gen", () => {
                         .resolves(techRecordsSearchPsv);
 
                     techRecordsPsvStub = cloneDeep(psvFailWithDefects);
-                    getTechRecordStub = sandbox
-                        .stub(certificateGenerationService, "callGetTechRecords")
-                        .resolves((techRecordsPsv) as any);
+                    callGetTechRecordSpy.mockResolvedValue(techRecordsPsv as any);
                 });
 
                 afterEach(() => {
-                    getTechRecordStub.restore();
-                    getTechRecordSearchStub.restore();
+                  callGetTechRecordSpy.mockClear();
+                  getTechRecordSearchStub.restore();
                 });
 
 
@@ -3880,15 +3781,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtHgvSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(trlPRS)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         }
@@ -3959,15 +3858,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtHgvSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(trlPRS, true)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -4074,15 +3971,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(psvPRS)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -4186,15 +4081,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(psvPRS, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -4301,15 +4194,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvWithDefectRectifiedAtTest)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -4414,15 +4305,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(hgvWithDefectRectifiedAtTest, true)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -4523,15 +4412,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -4596,9 +4483,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_model;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_make;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
@@ -4614,7 +4499,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -4723,16 +4608,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 resBody = payload.body;
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -4750,9 +4633,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsSearchPsv);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsPsv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -4766,7 +4647,7 @@ describe("cert-gen", () => {
                                     current: 1,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -5514,16 +5395,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -5567,28 +5446,26 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
                         const getOdometerHistoryStub = sandbox
-                            .stub(
-                                CertificateGenerationService.prototype,
-                                "getOdometerHistory"
-                            )
-                            .resolves(undefined);
+                          .stub(
+                              CertificateGenerationService.prototype,
+                              "getOdometerHistory"
+                          )
+                          .resolves(undefined);
                         return await certificateGenerationService
-                            .generatePayload(testResult)
-                            .then((payload: any) => {
-                                expect(payload).toEqual(expectedResult);
-                                getOdometerHistoryStub.restore();
-                                // getVehicleMakeAndModelStub.restore();
-                                getTechRecordStub.restore();
-                                getTechRecordSearchStub.restore();
-                            });
+                          .generatePayload(testResult)
+                          .then((payload: any) => {
+                            expect(payload).toEqual(expectedResult);
+                            getOdometerHistoryStub.restore();
+                            // getVehicleMakeAndModelStub.restore();
+                            callGetTechRecordSpy.mockClear();
+                            getTechRecordSearchStub.restore();
+                          });
+                      });
                     });
-                });
 
                 context("and signatures were found in the bucket", () => {
                     it("should return a VTG5 payload with signature", async () => {
@@ -5653,16 +5530,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -5680,9 +5555,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -5696,7 +5569,7 @@ describe("cert-gen", () => {
                                     current: 1,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -5808,15 +5681,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -5881,9 +5752,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
                         const getOdometerHistoryStub = sandbox
@@ -5893,12 +5762,12 @@ describe("cert-gen", () => {
                             )
                             .resolves(undefined);
                         return await certificateGenerationService
-                            .generatePayload(testResult)
-                            .then((payload: any) => {
-                                expect(payload).toEqual(expectedResult);
+                          .generatePayload(testResult)
+                          .then((payload: any) => {
+                              expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6006,16 +5875,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 resBody = payload.body;
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -6033,9 +5900,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -6049,7 +5914,7 @@ describe("cert-gen", () => {
                                     current: 1,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6124,15 +5989,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6185,9 +6048,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
                         const getOdometerHistoryStub = sandbox
@@ -6198,13 +6059,13 @@ describe("cert-gen", () => {
                             .resolves(undefined);
                         // Stub CertificateGenerationService getVehicleMakeAndModel method to return undefined value.
                         return await certificateGenerationService
-                            .generatePayload(testResult)
-                            .then((payload: any) => {
-                                expect(payload).toEqual(expectedResult);
+                          .generatePayload(testResult)
+                          .then((payload: any) => {
+                              expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
-                            });
+                          });
                     });
                 });
 
@@ -6279,15 +6140,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -6305,9 +6164,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtHgvSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -6321,7 +6178,7 @@ describe("cert-gen", () => {
                                     current: 2,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6373,15 +6230,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6426,9 +6281,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_model;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_make;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
@@ -6444,7 +6297,7 @@ describe("cert-gen", () => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6497,16 +6350,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -6525,9 +6376,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -6539,7 +6388,7 @@ describe("cert-gen", () => {
                                     current: 1,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6600,15 +6449,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -6672,15 +6519,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .catch((err: any) => {
                                 expect(err.statusCode).toEqual(500);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -6763,15 +6608,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6839,9 +6682,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
@@ -6856,7 +6697,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6933,9 +6774,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
@@ -6944,7 +6783,7 @@ describe("cert-gen", () => {
                                 resBody = payload.body;
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -6961,9 +6800,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -6975,7 +6812,7 @@ describe("cert-gen", () => {
                                     current: 1,
                                     total: 2,
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -7035,15 +6872,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
 
@@ -7099,9 +6934,7 @@ describe("cert-gen", () => {
                         delete techRecordResponseRwtMock.techRecord_make;
                         // @ts-ignore
                         delete techRecordResponseRwtMock.techRecord_model;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         // Make the functions return undefined
                         // Stub CertificateGenerationService getOdometerHistory method to return undefined value.
@@ -7116,7 +6949,7 @@ describe("cert-gen", () => {
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 getOdometerHistoryStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // getVehicleMakeAndModelStub.restore();
                             });
@@ -7179,15 +7012,13 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
@@ -7206,9 +7037,7 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         expect.assertions(3);
                         return await certificateGenerationService
@@ -7221,7 +7050,7 @@ describe("cert-gen", () => {
                                     total: 2,
 
                                 });
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -7282,16 +7111,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 getTechRecordSearchStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 // Remove the signature
                                 S3BucketMockService.buckets.pop();
                                 getTrailerRegistrationStub.restore();
@@ -7339,15 +7166,13 @@ describe("cert-gen", () => {
                         delete expectedResult.techRecord_make;
                         delete expectedResult.techRecord_model;
                         delete expectedResult.ApplicantDetails;
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                             });
                     });
@@ -7390,16 +7215,14 @@ describe("cert-gen", () => {
                             .resolves(techRecordsRwtSearch);
 
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                        const getTechRecordStub = sandbox
-                            .stub(certificateGenerationService, "callGetTechRecords")
-                            .resolves((techRecordResponseRwtMock) as any);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                         return await certificateGenerationService
                             .generatePayload(testResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 // getTechRecordStub.restore();
-                                getTechRecordStub.restore();
+                                callGetTechRecordSpy.mockClear();
                                 getTechRecordSearchStub.restore();
                                 S3BucketMockService.buckets.pop();
                             });
@@ -7430,15 +7253,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(testResult)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -7461,17 +7282,14 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(testResult)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     S3BucketMockService.buckets.pop();
-                                    getTechRecordStub.restore();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -7494,16 +7312,14 @@ describe("cert-gen", () => {
                         .resolves(techRecordsRwtSearch);
 
                     const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                    const getTechRecordStub = sandbox
-                        .stub(certificateGenerationService, "callGetTechRecords")
-                        .resolves((techRecordResponseRwtMock) as any);
+                    callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                     expect.assertions(1);
                     return await certificateGenerationService
                         .generateCertificate(testResult)
                         .then((response: any) => {
                             expect(response.certificateType).toEqual("RWT");
-                            getTechRecordStub.restore();
+                            callGetTechRecordSpy.mockClear();
                             getTechRecordSearchStub.restore();
                         });
                 });
@@ -7529,15 +7345,12 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             const payload = await certificateGenerationService
-                                .generatePayload(testResult);
+                              .generatePayload(testResult);
                             expect(payload).toEqual(expectedResult);
-                            getTechRecordStub.restore();
-                            getTechRecordStub.restore();
+                            callGetTechRecordSpy.mockClear();
                             getTechRecordSearchStub.restore();
                         });
                     });
@@ -7559,15 +7372,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             const payload = await certificateGenerationService
                                 .generatePayload(testResult);
                             expect(payload).toEqual(expectedResult);
                             S3BucketMockService.buckets.pop();
-                            getTechRecordStub.restore();
+                            callGetTechRecordSpy.mockClear();
                             getTechRecordSearchStub.restore();
                         });
                     });
@@ -7652,15 +7463,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(testResultReapplication)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -7733,15 +7542,13 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             return await certificateGenerationService
                                 .generatePayload(testResultReapplication)
                                 .then((payload: any) => {
                                     expect(payload).toEqual(expectedResult);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -7758,15 +7565,13 @@ describe("cert-gen", () => {
                                     .resolves(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                 return await certificateGenerationService
                                     .generatePayload(testResult)
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         getTechRecordSearchStub.restore();
                                     });
                             });
@@ -7789,17 +7594,14 @@ describe("cert-gen", () => {
                                     .resolves(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                 return await certificateGenerationService
                                     .generatePayload(testResult)
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         S3BucketMockService.buckets.pop();
-                                        getTechRecordStub.restore();
                                         getTechRecordSearchStub.restore();
                                     });
                             });
@@ -7814,9 +7616,7 @@ describe("cert-gen", () => {
                                         .resolves(techRecordsRwtSearch);
 
                                     const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                    const getTechRecordStub = sandbox
-                                        .stub(certificateGenerationService, "callGetTechRecords")
-                                        .resolves((techRecordResponseRwtMock) as any);
+                                    callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                     expect.assertions(3);
                                     return await certificateGenerationService
@@ -7830,7 +7630,7 @@ describe("cert-gen", () => {
                                                 current: 2,
                                                 total: 2,
                                             });
-                                            getTechRecordStub.restore();
+                                            callGetTechRecordSpy.mockClear();
                                             getTechRecordSearchStub.restore();
                                         });
                                 });
@@ -7917,15 +7717,13 @@ describe("cert-gen", () => {
                                     .resolves(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                 return await certificateGenerationService
                                     .generatePayload(testResultReapplication)
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         getTechRecordSearchStub.restore();
                                     });
                             });
@@ -7998,15 +7796,13 @@ describe("cert-gen", () => {
                                     .resolves(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                 return await certificateGenerationService
                                     .generatePayload(testResultReapplication)
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         getTechRecordSearchStub.restore();
                                     });
                             });
@@ -8023,15 +7819,13 @@ describe("cert-gen", () => {
                                     .resolves(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                 return await certificateGenerationService
                                     .generatePayload(testResult)
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         getTechRecordSearchStub.restore();
                                     });
                             });
@@ -8054,18 +7848,15 @@ describe("cert-gen", () => {
                                     .resolves(techRecordsRwtSearch);
 
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                 return await certificateGenerationService
                                     .generatePayload(testResult)
                                     .then((payload: any) => {
                                         expect(payload).toEqual(expectedResult);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         S3BucketMockService.buckets.pop();
-                                        getTechRecordStub.restore();
-                                        getTechRecordSearchStub.restore();
+                                                            getTechRecordSearchStub.restore();
                                     });
                             });
                         });
@@ -8079,9 +7870,7 @@ describe("cert-gen", () => {
                                         .resolves(techRecordsRwtSearch);
 
                                     const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                                    const getTechRecordStub = sandbox
-                                        .stub(certificateGenerationService, "callGetTechRecords")
-                                        .resolves((techRecordResponseRwtMock) as any);
+                                    callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                                     expect.assertions(3);
                                     return await certificateGenerationService
@@ -8095,7 +7884,7 @@ describe("cert-gen", () => {
                                                 current: 2,
                                                 total: 2,
                                             });
-                                            getTechRecordStub.restore();
+                                            callGetTechRecordSpy.mockClear();
                                             getTechRecordSearchStub.restore();
                                         });
                                 });
@@ -8125,9 +7914,7 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             const generatedCertificateResponse: IGeneratedCertificateResponse =
                                 await certificateGenerationService.generateCertificate(
@@ -8144,7 +7931,7 @@ describe("cert-gen", () => {
                                     expect(response.Key).toEqual(
                                         `${process.env.BRANCH}/${generatedCertificateResponse.fileName}`
                                     );
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                     S3BucketMockService.buckets.pop();
                                 });
@@ -8158,9 +7945,7 @@ describe("cert-gen", () => {
                                 .resolves(techRecordsRwtSearch);
 
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             const generatedCertificateResponse: IGeneratedCertificateResponse =
                                 await certificateGenerationService.generateCertificate(
@@ -8171,7 +7956,7 @@ describe("cert-gen", () => {
                                 .uploadCertificate(generatedCertificateResponse)
                                 .catch((error: any) => {
                                     expect(error).toBeInstanceOf(Error);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });

--- a/tests/unit/getWeightDetails.unitTest.ts
+++ b/tests/unit/getWeightDetails.unitTest.ts
@@ -13,12 +13,17 @@ import { IWeightDetails, ITestResult } from "../../src/models";
 import { HTTPError } from "../../src/models/HTTPError";
 import { S3BucketService } from "../../src/services/S3BucketService";
 import { LambdaService } from "../../src/services/LambdaService";
+import { TechRecordRepository } from "../../src/tech-record/TechRecordRepository";
 
 const sandbox = sinon.createSandbox();
 
 describe("cert-gen", () => {
     Container.set(S3BucketService, new S3BucketMockService());
     Container.set(LambdaService, new LambdaMockService());
+
+    const techRecordRepository = Container.get(TechRecordRepository);
+    const callGetTechRecordSpy = jest.spyOn(techRecordRepository, 'callGetTechRecords');
+    Container.set(TechRecordRepository, techRecordRepository);
 
     const certificateGenerationService = Container.get(CertificateGenerationService);
 
@@ -46,20 +51,17 @@ describe("cert-gen", () => {
                                 .stub(certificateGenerationService, "callSearchTechRecords")
                                 .resolves(techRecordsRwtSearch);
 
-
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             // expect.assertions(1);
                             await certificateGenerationService
-                                .getWeightDetails(testResult)
-                                .then((weightDetails) => {
-                                    expect(weightDetails).toEqual(expectedWeightDetails);
-                                    getTechRecordStub.restore();
-                                    getTechRecordSearchStub.restore();
-                                });
+                              .getWeightDetails(testResult)
+                              .then((weightDetails) => {
+                                expect(weightDetails).toEqual(expectedWeightDetails);
+                                callGetTechRecordSpy.mockClear();
+                                getTechRecordSearchStub.restore();
+                              });
                         });
                     });
                 }
@@ -82,20 +84,17 @@ describe("cert-gen", () => {
                                 .stub(certificateGenerationService, "callSearchTechRecords")
                                 .resolves(techRecordsRwtSearch);
 
-
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves((techRecordResponseRwtMock) as any);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             // expect.assertions(1);
                             await certificateGenerationService
-                                .getWeightDetails(testResult)
-                                .then((weightDetails) => {
-                                    expect(weightDetails).toEqual(expectedWeightDetails);
-                                    getTechRecordStub.restore();
-                                    getTechRecordSearchStub.restore();
-                                });
+                              .getWeightDetails(testResult)
+                              .then((weightDetails) => {
+                                expect(weightDetails).toEqual(expectedWeightDetails);
+                                callGetTechRecordSpy.mockClear();
+                                getTechRecordSearchStub.restore();
+                              });
                         });
                     });
                 }
@@ -115,9 +114,7 @@ describe("cert-gen", () => {
                                 .stub(certificateGenerationService, "callSearchTechRecords")
                                 .resolves(techRecordsRwtSearch);
 
-                            const getTechRecordStub = sandbox
-                                .stub(certificateGenerationService, "callGetTechRecords")
-                                .resolves(techRecordResponseRwtMock);
+                            callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             // expect.assertions(1);
                             const expectedError = new HTTPError(
@@ -128,7 +125,7 @@ describe("cert-gen", () => {
                                 .getWeightDetails(testResult)
                                 .catch((err) => {
                                     expect(err).toEqual(expectedError);
-                                    getTechRecordStub.restore();
+                                    callGetTechRecordSpy.mockClear();
                                     getTechRecordSearchStub.restore();
                                 });
                         });
@@ -152,9 +149,7 @@ describe("cert-gen", () => {
                             it("it should throw error", async () => {
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 techRecordResponseRwtMock.techRecord_axles = [];
-                                const getTechRecordStub = sandbox
-                                    .stub(certificateGenerationService, "callGetTechRecords")
-                                    .resolves((techRecordResponseRwtMock) as any);
+                                callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
                                 const getTechRecordSearchStub = sandbox
                                     .stub(certificateGenerationService, "callSearchTechRecords")
                                     .resolves(techRecordsRwtSearch);
@@ -169,7 +164,7 @@ describe("cert-gen", () => {
                                     .getWeightDetails(testResult)
                                     .catch((err) => {
                                         expect(err).toEqual(expectedError);
-                                        getTechRecordStub.restore();
+                                        callGetTechRecordSpy.mockClear();
                                         getTechRecordSearchStub.restore();
                                     });
                             });

--- a/tests/unit/getWeightDetails.unitTest.ts
+++ b/tests/unit/getWeightDetails.unitTest.ts
@@ -22,7 +22,8 @@ describe("cert-gen", () => {
     Container.set(LambdaService, new LambdaMockService());
 
     const techRecordRepository = Container.get(TechRecordRepository);
-    const callGetTechRecordSpy = jest.spyOn(techRecordRepository, 'callGetTechRecords');
+    const callGetTechRecordSpy = jest.spyOn(techRecordRepository, "callGetTechRecords");
+    const callSearchTechRecordSpy = jest.spyOn(techRecordRepository, "callSearchTechRecords");
     Container.set(TechRecordRepository, techRecordRepository);
 
     const certificateGenerationService = Container.get(CertificateGenerationService);
@@ -47,10 +48,8 @@ describe("cert-gen", () => {
                                 dgvw: 2000,
                                 weight2: 0,
                             };
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
 
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
@@ -60,7 +59,7 @@ describe("cert-gen", () => {
                               .then((weightDetails) => {
                                 expect(weightDetails).toEqual(expectedWeightDetails);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                               });
                         });
                     });
@@ -80,10 +79,8 @@ describe("cert-gen", () => {
                                 dgvw: 2000,
                                 weight2: 0,
                             };
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
 
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
                             const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
@@ -93,7 +90,7 @@ describe("cert-gen", () => {
                               .then((weightDetails) => {
                                 expect(weightDetails).toEqual(expectedWeightDetails);
                                 callGetTechRecordSpy.mockClear();
-                                getTechRecordSearchStub.restore();
+                                callSearchTechRecordSpy.mockClear();
                               });
                         });
                     });
@@ -110,10 +107,8 @@ describe("cert-gen", () => {
                     context("and tech record for vehicle is not found", () => {
                         it("should throw error", async () => {
                             const techRecordResponseRwtMock = undefined;
-                            const getTechRecordSearchStub = sandbox
-                                .stub(certificateGenerationService, "callSearchTechRecords")
-                                .resolves(techRecordsRwtSearch);
 
+                            callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
                             callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
                             // expect.assertions(1);
@@ -126,7 +121,7 @@ describe("cert-gen", () => {
                                 .catch((err) => {
                                     expect(err).toEqual(expectedError);
                                     callGetTechRecordSpy.mockClear();
-                                    getTechRecordSearchStub.restore();
+                                    callSearchTechRecordSpy.mockClear();
                                 });
                         });
                     });
@@ -150,9 +145,7 @@ describe("cert-gen", () => {
                                 const techRecordResponseRwtMock = cloneDeep(techRecordsRwt);
                                 techRecordResponseRwtMock.techRecord_axles = [];
                                 callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
-                                const getTechRecordSearchStub = sandbox
-                                    .stub(certificateGenerationService, "callSearchTechRecords")
-                                    .resolves(techRecordsRwtSearch);
+                                callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtSearch);
 
 
                                 // expect.assertions(1);
@@ -165,7 +158,7 @@ describe("cert-gen", () => {
                                     .catch((err) => {
                                         expect(err).toEqual(expectedError);
                                         callGetTechRecordSpy.mockClear();
-                                        getTechRecordSearchStub.restore();
+                                        callSearchTechRecordSpy.mockClear();
                                     });
                             });
                         }


### PR DESCRIPTION
## Refactor into repositories

Refactor all data entities into repository patterns. This simplifies readability, isolates concerns and promotes reuse of code.

[Refactor into repositories](https://dvsa.atlassian.net/browse/CB2-12312)

Note: This is dependent on the dependency injection PR https://github.com/dvsa/cvs-tsk-cert-gen/pull/185.

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
