### PR TITLE
feat(cb2-14701): add in recalls object to MOT pass/fails

### DIFF
--- a/src/certificate/commands/PassOrFailCertificateCommand.ts
+++ b/src/certificate/commands/PassOrFailCertificateCommand.ts
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import { Service } from 'typedi';
-import { ITestResult } from '../../models';
-import { ICertificatePayload } from '../../models';
+import { ICertificatePayload, ITestResult } from '../../models';
 import { CERTIFICATE_DATA, TEST_RESULTS, VEHICLE_TYPES } from '../../models/Enums';
 import { BasePayloadCommand } from '../ICertificatePayloadCommand';
 
@@ -69,6 +68,10 @@ export class PassOrFailCertificateCommand extends BasePayloadCommand {
 				? moment(testType.lastSeatbeltInstallationCheckDate).format('DD.MM.YYYY')
 				: '\u00A0',
 			SeatBeltNumber: testType.numberOfSeatbeltsFitted,
+			Recalls: {
+				manufacturer: testResult.recalls?.manufacturer ?? null,
+				hasRecall: testResult.recalls?.hasRecall ?? false,
+			},
 		};
 	}
 }

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -183,6 +183,10 @@ interface ITestResult {
 	testTypes: ITestType;
 	createdById?: string;
 	systemNumber: string;
+	recalls: {
+		manufacturer: string;
+		hasRecall: boolean;
+	};
 }
 
 // TODO: move to types definition interface after CB2-12580
@@ -217,10 +221,6 @@ interface ITestType {
 	defects: DefectDetailsSchema[];
 	requiredStandards?: IRequiredStandard[];
 	customDefects?: ICustomDefect[];
-	recalls: {
-		manufacturer: string;
-		hasRecall: boolean;
-	};
 }
 
 // TODO: move to types definition interface after CB2-12580

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -217,6 +217,10 @@ interface ITestType {
 	defects: DefectDetailsSchema[];
 	requiredStandards?: IRequiredStandard[];
 	customDefects?: ICustomDefect[];
+	recalls: {
+		manufacturer: string;
+		hasRecall: boolean;
+	};
 }
 
 // TODO: move to types definition interface after CB2-12580

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -6404,18 +6404,19 @@ describe("cert-gen", () => {
                         const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
                         callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
 
-                        testResult.recalls = {
+                        const duplicatedTestResult = cloneDeep(testResult);
+
+                        duplicatedTestResult.recalls = {
                             manufacturer: 'manufacturer',
                             hasRecall: true
                         }
 
                         return await certificateGenerationService
-                            .generatePayload(testResult)
+                            .generatePayload(duplicatedTestResult)
                             .then((payload: any) => {
                                 expect(payload).toEqual(expectedResult);
                                 callGetTechRecordSpy.mockClear();
                                 callSearchTechRecordSpy.mockClear();
-                                testResult.recalls = null;
                             });
                     });
                 });

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -6,15 +6,28 @@ const mockGetProfile = jest.fn();
 import * as fs from "fs";
 import { cloneDeep } from "lodash";
 import * as path from "path";
-import { Container } from "typedi";
 import sinon from "sinon";
+import { Container } from "typedi";
+import { CertificatePayloadStateBag } from "../../src/certificate/CertificatePayloadStateBag";
+import { DefectsCommand } from "../../src/certificate/commands/DefectsCommand";
+import { IvaCertificateCommand } from "../../src/certificate/commands/IvaCertificateCommand";
+import { MsvaCertificateCommand } from "../../src/certificate/commands/MsvaCertificateCommand";
+import { PassOrFailCertificateCommand } from "../../src/certificate/commands/PassOrFailCertificateCommand";
+import { DefectRepository } from "../../src/defect/DefectRepository";
+import { DefectService } from "../../src/defect/DefectService";
 import { certGen } from "../../src/functions/certGen";
 import { ICertificatePayload, IFeatureFlags, ITestResult } from "../../src/models";
+import { CERTIFICATE_DATA } from "../../src/models/Enums";
 import {
     CertificateGenerationService,
     IGeneratedCertificateResponse,
 } from "../../src/services/CertificateGenerationService";
 import { CertificateUploadService } from "../../src/services/CertificateUploadService";
+import { LambdaService } from "../../src/services/LambdaService";
+import { S3BucketService } from "../../src/services/S3BucketService";
+import { TechRecordRepository } from "../../src/tech-record/TechRecordRepository";
+import { TestResultRepository } from "../../src/test-result/TestResultRepository";
+import { TrailerRepository } from "../../src/trailer/TrailerRepository";
 import { LambdaMockService } from "../models/LambdaMockService";
 import { S3BucketMockService } from "../models/S3BucketMockService";
 import docGenIva30 from "../resources/doc-gen-payload-iva30.json";
@@ -29,19 +42,6 @@ import techRecordsRwtHgv from "../resources/tech-records-response-rwt-hgv.json";
 import techRecordsRwtSearch from "../resources/tech-records-response-rwt-search.json";
 import techRecordsRwt from "../resources/tech-records-response-rwt.json";
 import techRecordsSearchPsv from "../resources/tech-records-response-search-PSV.json";
-import { S3BucketService } from "../../src/services/S3BucketService";
-import { LambdaService } from "../../src/services/LambdaService";
-import { TrailerRepository } from "../../src/trailer/TrailerRepository";
-import { TechRecordRepository } from "../../src/tech-record/TechRecordRepository";
-import { TestResultRepository } from "../../src/test-result/TestResultRepository";
-import { DefectRepository } from "../../src/defect/DefectRepository";
-import { DefectService } from "../../src/defect/DefectService";
-import { MsvaCertificateCommand } from "../../src/certificate/commands/MsvaCertificateCommand";
-import { CERTIFICATE_DATA } from "../../src/models/Enums";
-import { IvaCertificateCommand } from "../../src/certificate/commands/IvaCertificateCommand";
-import { PassOrFailCertificateCommand } from "../../src/certificate/commands/PassOrFailCertificateCommand";
-import { DefectsCommand } from "../../src/certificate/commands/DefectsCommand";
-import { CertificatePayloadStateBag } from "../../src/certificate/CertificatePayloadStateBag";
 
 const sandbox = sinon.createSandbox();
 
@@ -92,6 +92,7 @@ describe("cert-gen", () => {
     afterEach(() => {
         sandbox.restore();
         callGetOdometerSpy.mockRestore();
+        S3BucketMockService.buckets.pop();
     });
     context("CertificateGenerationService", () => {
         LambdaMockService.populateFunctions();
@@ -144,6 +145,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -206,6 +211,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -276,6 +285,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -321,6 +334,10 @@ describe("cert-gen", () => {
                                 SeatBeltTested: "Yes",
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -401,6 +418,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -511,6 +532,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -579,6 +604,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -660,6 +689,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -728,6 +761,10 @@ describe("cert-gen", () => {
                                             date: "17.01.2019",
                                         },
                                     ],
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 },
                                 Signature: {
                                     ImageType: "png",
@@ -798,6 +835,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -867,6 +908,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -919,7 +964,11 @@ describe("cert-gen", () => {
                                     "62.1.a.i Reflectors, conspicuity markings and/or rear markers: incorrectly positioned. Nearside Front."
                                 ],
                                 Trn: "ABC123",
-                                IsTrailer: true
+                                IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -972,7 +1021,11 @@ describe("cert-gen", () => {
                                     "62.1.a.i Adlewyrchwyr, marciau amlygrwydd a/neu farcwyr cefn: wedi'i leoli'n anghywir. Ochr mewnol Blaen."
                                 ],
                                 Trn: "ABC123",
-                                IsTrailer: true
+                                IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1025,7 +1078,11 @@ describe("cert-gen", () => {
                                     "1.1 A registration plate: Note one"
                                 ],
                                 Trn: "ABC123",
-                                IsTrailer: true
+                                IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1078,7 +1135,11 @@ describe("cert-gen", () => {
                                     "1.1 A registration plate: Note one"
                                 ],
                                 Trn: "ABC123",
-                                IsTrailer: true
+                                IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1148,6 +1209,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1217,6 +1282,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1287,6 +1356,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1358,6 +1431,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1427,6 +1504,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1518,6 +1599,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1572,6 +1657,10 @@ describe("cert-gen", () => {
                                 AdvisoryDefects: [
                                     "5.1 Compression Ignition Engines Statutory Smoke Meter Test: null Dasdasdccc",
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1652,6 +1741,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1784,6 +1877,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1854,6 +1951,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1923,6 +2024,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -1993,6 +2098,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2065,6 +2174,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2141,6 +2254,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2219,6 +2336,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2307,6 +2428,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2379,6 +2504,10 @@ describe("cert-gen", () => {
                                         value: 380000
                                     }
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2459,6 +2588,10 @@ describe("cert-gen", () => {
                                         value: 380000
                                     }
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2533,6 +2666,10 @@ describe("cert-gen", () => {
                                         value: 380000
                                     }
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2611,6 +2748,10 @@ describe("cert-gen", () => {
                                         value: 380000
                                     }
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2664,6 +2805,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2720,6 +2865,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2775,6 +2924,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2831,6 +2984,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2889,6 +3046,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -2951,6 +3112,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3015,6 +3180,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3089,6 +3258,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3154,6 +3327,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3228,6 +3405,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3291,6 +3472,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3364,6 +3549,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -3430,7 +3619,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3497,7 +3690,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3562,7 +3759,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3629,7 +3830,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3697,7 +3902,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3771,7 +3980,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3845,7 +4058,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -3933,7 +4150,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4001,7 +4222,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4075,7 +4300,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4143,7 +4372,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4217,7 +4450,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4276,7 +4513,11 @@ describe("cert-gen", () => {
                                     TestStationName: "Abshire-Kub",
                                     TestStationPNumber: "09-4129632",
                                     Trn: "ABC123",
-                                    VehicleEuClassification: "M1"
+                                    VehicleEuClassification: "M1",
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 },
                                 FAIL_DATA: {
                                     CountryOfRegistrationCode: "gb",
@@ -4302,7 +4543,11 @@ describe("cert-gen", () => {
                                     TestStationName: "Abshire-Kub",
                                     TestStationPNumber: "09-4129632",
                                     Trn: "ABC123",
-                                    VehicleEuClassification: "M1"
+                                    VehicleEuClassification: "M1",
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 },
                                 Signature: {
                                     ImageData: null,
@@ -4348,7 +4593,11 @@ describe("cert-gen", () => {
                                     TestStationName: "Abshire-Kub",
                                     TestStationPNumber: "09-4129632",
                                     Trn: "ABC123",
-                                    VehicleEuClassification: "M1"
+                                    VehicleEuClassification: "M1",
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 },
                                 FAIL_DATA: {
                                     CountryOfRegistrationCode: "gb",
@@ -4377,7 +4626,11 @@ describe("cert-gen", () => {
                                     TestStationName: "Abshire-Kub",
                                     TestStationPNumber: "09-4129632",
                                     Trn: "ABC123",
-                                    VehicleEuClassification: "M1"
+                                    VehicleEuClassification: "M1",
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 },
                                 Signature: {
                                     ImageData: null,
@@ -4445,7 +4698,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 CountryOfRegistrationCode: "gb",
@@ -4487,7 +4744,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4551,7 +4812,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 CountryOfRegistrationCode: "gb",
@@ -4596,7 +4861,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4664,7 +4933,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 CountryOfRegistrationCode: "gb",
@@ -4706,7 +4979,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4770,7 +5047,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 CountryOfRegistrationCode: "gb",
@@ -4815,7 +5096,11 @@ describe("cert-gen", () => {
                                 TestNumber: "W01A00310",
                                 TestStationName: "Abshire-Kub",
                                 TestStationPNumber: "09-4129632",
-                                VehicleEuClassification: "M1"
+                                VehicleEuClassification: "M1",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageData: null,
@@ -4883,6 +5168,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -4923,6 +5212,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -4967,6 +5260,10 @@ describe("cert-gen", () => {
                                 SeatBeltTested: "Yes",
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -4988,6 +5285,10 @@ describe("cert-gen", () => {
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
                                 PRSDefects: ["1.1.a A registration plate: missing. Front."],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -5060,6 +5361,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -5100,6 +5405,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -5204,6 +5513,10 @@ describe("cert-gen", () => {
                                         "5.1 Compression Ignition Engines Statutory Smoke Meter Test: null Dasdasdccc",
                                     ],
                                     PRSDefects: ["1.1.a A registration plate: missing. Front."],
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 }
                             };
 
@@ -5268,6 +5581,10 @@ describe("cert-gen", () => {
                                     PRSDefects: [
                                         "54.1.a.ii Power steering: not working correctly and obviously affects steering control. Axles: 7. Inner Offside. Asdasd",
                                     ],
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 }
                             };
 
@@ -5332,6 +5649,10 @@ describe("cert-gen", () => {
                                         "5.1 Compression Ignition Engines Statutory Smoke Meter Test: null Dasdasdccc",
                                     ],
                                     PRSDefects: undefined,
+                                    Recalls: {
+                                        manufacturer: null,
+                                        hasRecall: false
+                                    }
                                 }
                             };
 
@@ -6000,6 +6321,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6046,6 +6371,10 @@ describe("cert-gen", () => {
                                 SeatBeltTested: "Yes",
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6117,6 +6446,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6233,6 +6566,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -6273,6 +6610,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6318,6 +6659,10 @@ describe("cert-gen", () => {
                                 SeatBeltTested: "Yes",
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -6339,6 +6684,10 @@ describe("cert-gen", () => {
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
                                 PRSDefects: ["1.1.a A registration plate: missing. Front."],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6410,6 +6759,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -6450,6 +6803,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6569,6 +6926,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6622,6 +6983,10 @@ describe("cert-gen", () => {
                                 AdvisoryDefects: [
                                     "5.1 Compression Ignition Engines Statutory Smoke Meter Test: null Dasdasdccc",
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6702,6 +7067,10 @@ describe("cert-gen", () => {
                                         date: "17.01.2019",
                                     },
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6796,7 +7165,11 @@ describe("cert-gen", () => {
                                 Make: "STANLEY",
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
-                                IsTrailer: true
+                                IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6843,6 +7216,10 @@ describe("cert-gen", () => {
                                 SeatBeltTested: "Yes",
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6898,6 +7275,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -6986,6 +7367,10 @@ describe("cert-gen", () => {
                                 Make: "STANLEY",
                                 Model: "AUTOTRL",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7102,6 +7487,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -7126,6 +7515,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7173,6 +7566,10 @@ describe("cert-gen", () => {
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
                                 Make: "STANLEY",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -7195,7 +7592,11 @@ describe("cert-gen", () => {
                                 SeatBeltPreviousCheckDate: "26.02.2019",
                                 SeatBeltNumber: 2,
                                 PRSDefects: ["1.1.a A registration plate: missing. Front."],
-                                Make: "STANLEY"
+                                Make: "STANLEY",
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7250,6 +7651,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             FAIL_DATA: {
                                 TestNumber: "W01A00310",
@@ -7274,6 +7679,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7377,6 +7786,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7434,6 +7847,10 @@ describe("cert-gen", () => {
                                 AdvisoryDefects: [
                                     "5.1 Compression Ignition Engines Statutory Smoke Meter Test: null Dasdasdccc",
                                 ],
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7498,6 +7915,10 @@ describe("cert-gen", () => {
                                 Model: "AUTOTRL",
                                 Trn: "ABC123",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",
@@ -7596,6 +8017,10 @@ describe("cert-gen", () => {
                                 Make: "STANLEY",
                                 Model: "AUTOTRL",
                                 IsTrailer: true,
+                                Recalls: {
+                                    manufacturer: null,
+                                    hasRecall: false
+                                }
                             },
                             Signature: {
                                 ImageType: "png",

--- a/tests/unit/certGen.unitTest.ts
+++ b/tests/unit/certGen.unitTest.ts
@@ -6346,6 +6346,78 @@ describe("cert-gen", () => {
                                 callSearchTechRecordSpy.mockClear();
                             });
                     });
+
+                    it("should return a VTG5 payload without signature but with a recalls object populated", async () => {
+                        const expectedResult: any = {
+                            Watermark: "NOT VALID",
+                            DATA: {
+                                TestNumber: "W01A00310",
+                                TestStationPNumber: "09-4129632",
+                                TestStationName: "Abshire-Kub",
+                                CurrentOdometer: {
+                                    value: 12312,
+                                    unit: "kilometres",
+                                },
+                                IssuersName: "CVS Dev1",
+                                DateOfTheTest: "26.02.2019",
+                                CountryOfRegistrationCode: "gb",
+                                VehicleEuClassification: "M1",
+                                RawVIN: "P012301098765",
+                                RawVRM: "VM14MDT",
+                                ExpiryDate: "25.02.2020",
+                                EarliestDateOfTheNextTest: "01.11.2019",
+                                SeatBeltTested: "Yes",
+                                SeatBeltPreviousCheckDate: "26.02.2019",
+                                SeatBeltNumber: 2,
+                                Make: "Isuzu",
+                                Model: "FM",
+                                OdometerHistoryList: [
+                                    {
+                                        value: 400000,
+                                        unit: "kilometres",
+                                        date: "19.01.2019",
+                                    },
+                                    {
+                                        value: 390000,
+                                        unit: "kilometres",
+                                        date: "18.01.2019",
+                                    },
+                                    {
+                                        value: 380000,
+                                        unit: "kilometres",
+                                        date: "17.01.2019",
+                                    },
+                                ],
+                                Recalls: {
+                                    manufacturer: 'manufacturer',
+                                    hasRecall: true
+                                }
+                            },
+                            Signature: {
+                                ImageType: "png",
+                                ImageData: null,
+                            },
+                        };
+
+                        callSearchTechRecordSpy.mockResolvedValue(techRecordsRwtHgvSearch);
+
+                        const techRecordResponseRwtMock = cloneDeep(techRecordsRwtHgv);
+                        callGetTechRecordSpy.mockResolvedValue(techRecordResponseRwtMock as any);
+
+                        testResult.recalls = {
+                            manufacturer: 'manufacturer',
+                            hasRecall: true
+                        }
+
+                        return await certificateGenerationService
+                            .generatePayload(testResult)
+                            .then((payload: any) => {
+                                expect(payload).toEqual(expectedResult);
+                                callGetTechRecordSpy.mockClear();
+                                callSearchTechRecordSpy.mockClear();
+                                testResult.recalls = null;
+                            });
+                    });
                 });
 
                 context("and lambda-to-lambda calls were unsuccessful", () => {


### PR DESCRIPTION
## Ticket title

MOT certs now have the recalls object placed on it for Doc-gen to make use of.
[https://dvsa.atlassian.net/browse/CB2-14701](14701)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
